### PR TITLE
Support simple query

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -22,6 +22,7 @@ defmodule Postgrex.Protocol.Messages do
                              :result_formats]
       defrecordp :msg_execute, [:name_port, :max_rows]
       defrecordp :msg_sync, []
+      defrecordp :msg_query, [:query]
       defrecordp :msg_bind_complete, []
       defrecordp :msg_portal_suspend, []
       defrecordp :msg_data_row, [:values]
@@ -227,6 +228,12 @@ defmodule Postgrex.Protocol do
   # sync
   defp to_binary(msg_sync()) do
     { ?S, "" }
+  end
+
+  # query
+  defp to_binary(msg_query(query: query)) do
+    IO.puts "Query #{query}"
+    { ?Q, [query, 0]}
   end
 
   # terminate

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -216,6 +216,14 @@ defmodule QueryTest do
     assert [{42}] = query("SELECT 42")
   end
 
+  test "simple query", context do
+    assert { :ok, res } = P.simple_query(context[:pid], "SELECT 5; SELECT 123 AS a, 456 AS b; SELECT 5;")
+    assert Postgrex.Result[] = res
+    assert res.command == :select
+    assert res.columns == ["a", "b"]
+    assert res.num_rows == 1
+  end
+
   test "async test", context do
     self_pid = self
     Enum.each(1..10, fn _ ->

--- a/test/simple_query_test.exs
+++ b/test/simple_query_test.exs
@@ -1,0 +1,24 @@
+defmodule QueryTest do
+  use ExUnit.Case, async: true
+  import Postgrex.TestHelper
+  alias Postgrex.Connection, as: P
+
+  setup do
+    opts = [ hostname: "localhost", username: "postgres",
+             password: "postgres", database: "postgrex_test" ]
+    { :ok, pid } = P.start_link(opts)
+    { :ok, [pid: pid] }
+  end
+
+  teardown context do
+    :ok = P.stop(context[:pid])
+  end
+
+  test "simple query", context do
+    assert { :ok, res } = P.simple_query(context[:pid], "SELECT 5; SELECT 123 AS a, 456 AS b; SELECT 5;")
+    assert Postgrex.Result[] = res
+    assert res.command == :select
+    assert res.columns == ["a", "b"]
+    assert res.num_rows == 1
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,7 +30,7 @@ CREATE TABLE query (a int, b text);
 
 cmds = [
   ~s(psql -U postgres -c "DROP DATABASE IF EXISTS postgrex_test;"),
-  ~s(psql -U postgres -c "CREATE DATABASE postgrex_test ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"),
+  ~s(psql -U postgres -c "CREATE DATABASE postgrex_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"),
   ~s(psql -U postgres -d postgrex_test -c "#{sql}")
 ]
 


### PR DESCRIPTION
As discussed on IRC:

I’ve got a problem implementing simple query in postgrex. currently in the :describing state it always follows up with a send_params. I don’t want that for the simple query obviously. should I just add a field to the state record checking if we’re doing a simple or extended query or do you have a better suggestion?

- [ ] Add doc  about what simple query is and why you shouldn't use it except for the cases where you want to use it.