### PR TITLE
Add docs badge to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ before_script:
   - sudo service postgresql restart
 script:
   - mix test
+after_script:
+  - MIX_ENV=docs mix do deps.get, inch.report
 env:
   global:
     -PGUSER=postgres

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Postgrex
 
 [![Build Status](https://travis-ci.org/ericmj/postgrex.png?branch=master)](https://travis-ci.org/ericmj/postgrex)
+[![Inline docs](http://inch-ci.org/github/ericmj/postgrex.svg?branch=master)](http://inch-ci.org/github/ericmj/postgrex)
 
 PostgreSQL driver for Elixir.
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Postgrex.Mixfile do
   defp deps do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
-     {:decimal, "~> 0.2.3"}]
+     {:decimal, "~> 0.2.3"},
+     {:inch_ex, only: :docs}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,6 @@
   "earmark": {:package, "0.1.10"},
   "ex_doc": {:package, "0.6.0"},
   "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
+  "inch_ex": {:package, "0.2.1"},
+  "json": {:package, "0.3.2"},
   "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []}}


### PR DESCRIPTION
Hi there,

this patch would add a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/ericmj/postgrex.svg)](http://inch-ci.org/github/ericmj/postgrex)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Elixir programmers to document their public modules/functions. Your status page is http://inch-ci.org/github/ericmj/postgrex/

The Elixir support is still new, but [I already convinced Chris McCord and José Valim](https://github.com/phoenixframework/phoenix/pull/404) to include it in the Phoenix Framework's README and we are having an active discussion about what can be changed to make this a useful tool for the Elixir community.

What do you think?