### PR TITLE
Add support for Postgres range types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,17 @@ iex> Postgrex.Connection.query(pid, "INSERT INTO comments (user_id, text) VALUES
     interval        { 14, 40, 10920 } **
     array           [ 1, 2, 3 ]
     composite type  { 42, "title", "content" }
+    int4range/      { 1, 5 } ***
+    int8range
+    daterange       { { 2014, 1, 1 }, { 2014, 12, 31 } }
+    tsrange/        { { { 2014, 1, 1}, { 0, 37, 14 } }, { { 2014, 12, 31 }, { 0, 37, 14 } } }
+    tstzrange
 
 \* [Decimal](http://github.com/ericmj/decimal)
 
 \*\* interval is encoded as `{ months, days, seconds }`.
+
+\*\*\* ranges expect and return the lower and upper bounds as inclusive (e.g., {1, 4} = 1, 2, 3, 4)
 
 ## Custom encoder and decoder example
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -83,7 +83,7 @@ defmodule QueryTest do
     assert [{[{1, "2"}]}] = query("SELECT ARRAY[(1, '2')::composite1]", [])
   end
 
-  @tag min_pg_version: 9.2
+  @tag min_pg_version: "9.2"
   test "decode range", context do
     assert [{{2,4}}] = query("SELECT '(1,5)'::int4range", [])
     assert [{{1,6}}] = query("SELECT '[1,6]'::int4range", [])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,7 +4,14 @@ else
   []
 end
 
-ExUnit.configure exclude: exclude
+version_exclusions = case System.get_env("PGVERSION") do
+  v when is_binary(v) ->
+    Enum.filter(["8.4", "9.0", "9.1", "9.2", "9.3", "9.4"], fn x -> x > v end) |> Enum.map(&{:min_pg_version, &1})
+  _ ->
+    []
+end
+
+ExUnit.configure exclude: version_exclusions ++ exclude
 
 ExUnit.start
 


### PR DESCRIPTION
This PR adds basic support for Postgres' built-in range type (binary format). Currently it handles 5 of the 6 range types: int4range, int8range, daterange, tsrange, and tstzrange. The one that's missing is numrange for Numerics.

Each range type expects and returns a tuple with elements that follow the existing data representation for int, date, and timestamp (e.g., `{1,3}` and `{{2014,1,1},{2014,12,31}}`). More structured representations would best be handled downstream with custom encoder/decoders, like Ecto does with Ecto.Date and Ecto.DateTime.

For open-ended ranges, I went with the existing `:"-inf"` and `:inf` style over `nil` values. Using `nil` would be closer to the Postgres query syntax, but `inf` makes the actual behavior more explicit.

One last thing to note is that the values are all treated as lower/upper inclusive ranges, smoothing out a quirk of how Postgres serializes/returns range values.

Postgres will return range values as lower-inclusive/upper-exclusive, regardless of how the initial query is structured. So, e.g., Postgres would return 1 and 6 as the bounds of `SELECT '[1,5]'::int4range`, but the upper-inclusive bit flag would indicate 6 is not included in the range.

To more closely match input/output, as well as the behavior of Elixir's Range type, the decoder functions convert to inclusive upper bounds on the fly. So the same query above returns `{1, 5}` after decoding.