### PR TITLE
JSON datatype support (PostgreSQL 9.2+)

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Types do
   require Decimal
 
   @types ~w(bool bpchar text varchar bytea int2 int4 int8 float4 float8 numeric
-            date time timetz timestamp timestamptz interval)
+            date time timetz timestamp timestamptz interval json)
 
   @gd_epoch :calendar.date_to_gregorian_days({2000, 1, 1})
   @gs_epoch :calendar.datetime_to_gregorian_seconds({{2000, 1, 1}, {0, 0, 0}})
@@ -176,6 +176,8 @@ defmodule Postgrex.Types do
     do: decode_array(bin, extra)
   def decode_binary(%TypeInfo{sender: "record"}, extra, bin),
     do: decode_record(bin, extra)
+  def decode_binary(%TypeInfo{sender: "json"}, _, bin),
+    do: Poison.Parser.parse!(bin)
   def decode_binary(%TypeInfo{}, _, _),
     do: nil
 
@@ -234,6 +236,8 @@ defmodule Postgrex.Types do
     do: encode_array(list, oid, extra)
   def encode(%TypeInfo{sender: "record", oid: oid}, extra, tuple) when is_tuple(tuple),
     do: encode_record(tuple, oid, extra)
+  def encode(%TypeInfo{sender: "json"}, _, json),
+    do: Poison.Encoder.encode(json, [])
   def encode(%TypeInfo{}, _, _),
     do: nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Postgrex.Mixfile do
   defp deps do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
-     {:decimal, "~> 0.2.3"}]
+     {:decimal, "~> 0.2.3"},
+     {:poison, "~> 1.2.1"}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
-%{"decimal": {:package, "0.2.4"},
-  "earmark": {:package, "0.1.10"},
-  "ex_doc": {:package, "0.6.0"},
+%{"decimal": {:hex, :decimal, "0.2.4"},
+  "earmark": {:hex, :earmark, "0.1.10"},
+  "ex_doc": {:hex, :ex_doc, "0.6.0"},
   "hoedown": {:git, "git://github.com/hoedown/hoedown.git", "0610117f44b173a4e2112afb2f510156a32355b5", []},
-  "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []}}
+  "markdown": {:git, "git://github.com/devinus/markdown.git", "a428908a6dd88f351775d1d3da530a1a2aa0d6cb", []},
+  "poison": {:hex, :poison, "1.2.1"}}

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -152,6 +152,11 @@ defmodule QueryTest do
       query("SELECT $1::interval", [{14,40,10920}])
   end
 
+  @tag requires_json_datatype: true
+  test "encode / decode json", context do
+    assert [{%{"hello" => "there"}}] = query("SELECT $1::json", [%{"hello" => "there"}])
+  end
+
   test "encode arrays", context do
     assert [{[]}] = query("SELECT $1::integer[]", [[]])
     assert [{[1]}] = query("SELECT $1::integer[]", [[1]])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,18 @@
+version_string = System.get_env("PGVERSION")
+if Regex.match?(~r/^\d.\d$/, version_string) do
+  version_string = version_string <> ".0"
+end
+{:ok, postgres_version} = Version.parse(version_string)
+
+# PostgreSQL JSON datatype was added in 9.2.
+exclude = if Version.match?(postgres_version, "< 9.2.0") do
+  [requires_json_datatype: true]
+else
+  []
+end
+
+ExUnit.configure exclude: exclude
+
 ExUnit.start
 
 {:ok, _} = :application.ensure_all_started(:crypto)


### PR DESCRIPTION
Not sure if you want this built in, since JSON is in the custom encoder / decoder example section (and introduces an external dependency).