### PR TITLE
Make the Travis CI badge an SVG image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Postgrex
 
-[![Build Status](https://travis-ci.org/ericmj/postgrex.png?branch=master)](https://travis-ci.org/ericmj/postgrex)
+[![Build Status](https://travis-ci.org/ericmj/postgrex.svg?branch=master)](https://travis-ci.org/ericmj/postgrex)
 
 PostgreSQL driver for Elixir.
 


### PR DESCRIPTION
Nice and easy :smile:, just changed `.png` to `.svg` in the link to the badge.