### PR TITLE
add support for citext (case insensitive text extension)

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -7,7 +7,7 @@ defmodule Postgrex.Types do
   require Decimal
   use Bitwise, only_operators: true
 
-  @types ~w(bool bpchar text varchar bytea int2 int4 int8 float4 float8 numeric
+  @types ~w(bool bpchar text varchar citext bytea int2 int4 int8 float4 float8 numeric
             uuid date time timetz timestamp timestamptz interval range)
 
   @gd_epoch :calendar.date_to_gregorian_days({2000, 1, 1})
@@ -136,6 +136,8 @@ defmodule Postgrex.Types do
     do: bin
   def decode_binary(%TypeInfo{sender: "varchar"}, _, bin),
     do: bin
+  def decode_binary(%TypeInfo{sender: "citext"}, _, bin),
+    do: bin
   def decode_binary(%TypeInfo{sender: "bytea"}, _, bin),
     do: bin
   def decode_binary(%TypeInfo{sender: "int2"}, _, <<n :: int16>>),
@@ -199,6 +201,8 @@ defmodule Postgrex.Types do
   def encode(%TypeInfo{sender: "text"}, _, bin) when is_binary(bin),
     do: bin
   def encode(%TypeInfo{sender: "varchar"}, _, bin) when is_binary(bin),
+    do: bin
+  def encode(%TypeInfo{sender: "citext"}, _, bin) when is_binary(bin),
     do: bin
   def encode(%TypeInfo{sender: "bytea"}, _, bin) when is_binary(bin),
     do: bin


### PR DESCRIPTION
Support citext http://www.postgresql.org/docs/9.4/static/citext.html

citext is a commonly installed extension for Postgres and while it appears to work without explicit inclusion, the array variant `citext[]` does not (casts to binary instead of list).  This pull request remedies this.  I did not add a test because it would require the installation of the citext extension.  Open to any thoughts or feedback, have tested in my app with postgres versions 9.1-9.4.

Thanks,

Troy