### PR TITLE
use regex to parse postgres version numbers

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -26,22 +26,15 @@ defmodule Postgrex.Utils do
     true
   end
 
+  @doc """
+  Converts pg major.minor.patch (http://www.postgresql.org/support/versioning) version to an integer
+  """
   def version_to_int(version) do
-    parts = binary_split(version, ".", 2)
-    [major, minor, patch] = Enum.map(parts, &:erlang.binary_to_integer/1)
-    major*10_000 + minor*100 + patch
-  end
-
-  def binary_split(binary, _pattern, 0) do
-    [binary]
-  end
-
-  def binary_split(binary, pattern, max) do
-    case :binary.split(binary, pattern) do
-      [match, rest] ->
-        [match|binary_split(rest, pattern, max-1)]
-      [binary] ->
-        [binary]
+    parts = Regex.run(~r/(\d{1,2})\.?(\d{1,3})?\.?(\d{1,3})?/, version, capture: :all_but_first)
+    case Enum.map(parts, &:erlang.binary_to_integer/1) do
+        [major, minor, patch] -> major*10_000 + minor*100 + patch
+        [major, minor] -> major*10_000 + minor*100
+        [major] -> major*10_000 
     end
   end
 end

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -30,11 +30,10 @@ defmodule Postgrex.Utils do
   Converts pg major.minor.patch (http://www.postgresql.org/support/versioning) version to an integer
   """
   def version_to_int(version) do
-    parts = Regex.run(~r/(\d{1,2})\.?(\d{1,3})?\.?(\d{1,3})?/, version, capture: :all_but_first)
-    case Enum.map(parts, &:erlang.binary_to_integer/1) do
-        [major, minor, patch] -> major*10_000 + minor*100 + patch
-        [major, minor] -> major*10_000 + minor*100
-        [major] -> major*10_000 
+    case version |> String.split(".") |> Enum.map(fn (part) -> elem(Integer.parse(part),0) end) do
+      [major, minor, patch] -> major*10_000 + minor*100 + patch
+      [major, minor] -> major*10_000 + minor*100
+      [major] -> major*10_000 
     end
   end
 end


### PR DESCRIPTION
got an error parsing "9.4beta2", see #53 

This pull request uses a regex and a case, the regex may be hard to read for some but overall this pr also lowers the LOC ;)  On http://www.postgresql.org/support/versioning they do not mention if a minor version is required, but in the regex I made it optional.

Thanks