### PR TITLE
Support oid and all its aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Enhancements
   * Keep the postgres error code in `:pg_code`
+  * Support oid types and all its aliases (regclass etc)
 
 * Backwards incompatible changes
   * Rename `:msec` field to `:usec` on `Postgrex.Time` and `Postgrex.Timestamp`

--- a/README.md
+++ b/README.md
@@ -93,6 +93,33 @@ end
 Postgrex.Connection.start_link(extensions: [{Extensions.JSON, library: Poison}], ...)
 ```
 
+## OID type encoding
+
+Unlike most Postgres client libraries Postgrex uses the binary protocol to talk to Postgres. This
+allows for efficient encoding of types (e.g. 4-byte integers are encoded as 4 bytes, not as a string
+of digits) and automatic support for arrays and composite types.
+
+Unfortunately the Postgres binary protocol transports [OID types](http://www.postgresql.org/docs/current/static/datatype-oid.html#DATATYPE-OID-TABLE)
+as integers while the text protocol transports them as string of their name, if one exists, and otherwise as integer.
+
+This means you either need to supply oid types as integers or perform an explicit cast (which would
+be automatic when using the text protocol) in the query.
+
+```elixir
+# Fails since $1 is regclass not text.
+query("select nextval($1)", ["some_sequence"])
+
+# Perform an explicit cast, this would happen automatically when using a client library that uses
+# the text protocol.
+query("select nextval($1::text::regclass)", ["some_sequence"])
+
+# Determine the oid once and store it for later usage. This is the most efficient way, since
+# Postgres only has to perform the lookup once. Client libraries using the text protocol do not
+# support this.
+%{rows: [{sequence_oid}]} = query("select $1::text::regclass", ["some_sequence"])
+query("select nextval($1)", [sequence_oid])
+```
+
 ## Contributing
 
 To contribute you need to compile Postgrex from source and test it:

--- a/README.md
+++ b/README.md
@@ -95,11 +95,12 @@ Postgrex.Connection.start_link(extensions: [{Extensions.JSON, library: Poison}],
 
 ## OID type encoding
 
-Unlike most Postgres client libraries Postgrex uses the binary protocol to talk to Postgres. This
-allows for efficient encoding of types (e.g. 4-byte integers are encoded as 4 bytes, not as a string
-of digits) and automatic support for arrays and composite types.
+PostgreSQL's wire protocol supports encoding types either as text or as binary. Unlike most
+client libraries Postgrex uses the binary protocol, not the text protocol. This allows for efficient
+encoding of types (e.g. 4-byte integers are encoded as 4 bytes, not as a string of digits) and
+automatic support for arrays and composite types.
 
-Unfortunately the Postgres binary protocol transports [OID types](http://www.postgresql.org/docs/current/static/datatype-oid.html#DATATYPE-OID-TABLE)
+Unfortunately the PostgreSQL binary protocol transports [OID types](http://www.postgresql.org/docs/current/static/datatype-oid.html#DATATYPE-OID-TABLE)
 as integers while the text protocol transports them as string of their name, if one exists, and otherwise as integer.
 
 This means you either need to supply oid types as integers or perform an explicit cast (which would
@@ -114,7 +115,7 @@ query("select nextval($1)", ["some_sequence"])
 query("select nextval($1::text::regclass)", ["some_sequence"])
 
 # Determine the oid once and store it for later usage. This is the most efficient way, since
-# Postgres only has to perform the lookup once. Client libraries using the text protocol do not
+# PostgreSQL only has to perform the lookup once. Client libraries using the text protocol do not
 # support this.
 %{rows: [{sequence_oid}]} = query("select $1::text::regclass", ["some_sequence"])
 query("select nextval($1)", [sequence_oid])

--- a/lib/postgrex/binary_utils.ex
+++ b/lib/postgrex/binary_utils.ex
@@ -17,6 +17,10 @@ defmodule Postgrex.BinaryUtils do
     quote do: unsigned-16
   end
 
+  defmacro uint32 do
+    quote do: unsigned-32
+  end
+
   defmacro int8 do
     quote do: signed-8
   end

--- a/lib/postgrex/extensions/binary.ex
+++ b/lib/postgrex/extensions/binary.ex
@@ -28,11 +28,13 @@ defmodule Postgrex.Extensions.Binary do
   @int2_range -32768..32767
   @int4_range -2147483648..2147483647
   @int8_range -9223372036854775808..9223372036854775807
+  @oid_range 0..4294967295
 
   @senders ~w(boolsend bpcharsend textsend citextsend varcharsend byteasend
               int2send int4send int8send float4send float8send numeric_send
               uuid_send date_send time_send timetz_send timestamp_send
-              timestamptz_send interval_send enum_send unknownsend)
+              timestamptz_send interval_send enum_send oidsend unknownsend
+              regprocsend regproceduresend regopersend regoperatorsend regclasssend regtypesend)
 
   def init(parameters, _opts),
     do: parameters["server_version"] |> Postgrex.Utils.version_to_int
@@ -113,6 +115,20 @@ defmodule Postgrex.Extensions.Binary do
     do: encode_record(tuple, elem_oids, types)
   def encode(%TypeInfo{send: "range_send", base_type: oid}, %Postgrex.Range{} = range, types, _),
     do: encode_range(range, oid, types)
+  def encode(%TypeInfo{send: "oidsend"}, n, _, _)when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regprocsend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regproceduresend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regopersend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regoperatorsend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regclasssend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
+  def encode(%TypeInfo{send: "regtypesend"}, n, _, _) when is_integer(n) and n in @oid_range,
+    do: <<n :: uint32>>
 
   defp encode_numeric(dec) do
     if Decimal.nan?(dec) do
@@ -371,6 +387,20 @@ defmodule Postgrex.Extensions.Binary do
     do: decode_record(bin, types)
   def decode(%TypeInfo{send: "range_send", base_type: oid}, bin, types, _),
     do: decode_range(bin, oid, types)
+  def decode(%TypeInfo{send: "oidsend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regprocsend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regproceduresend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regopersend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regoperatorsend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regclasssend"}, <<n :: uint32>>, _, _),
+    do: n
+  def decode(%TypeInfo{send: "regtypesend"}, <<n :: uint32>>, _, _),
+    do: n
 
   defp decode_numeric(<<ndigits :: int16, weight :: int16, sign :: uint16, scale :: int16, tail :: binary>>) do
     decode_numeric(ndigits, weight, sign, scale, tail)

--- a/lib/postgrex/messages.ex
+++ b/lib/postgrex/messages.ex
@@ -182,7 +182,7 @@ defmodule Postgrex.Messages do
 
   # parse
   defp encode(msg_parse(name: name, query: query, type_oids: oids)) do
-    oids = for oid <- oids, into: "", do: <<oid :: int32>>
+    oids = for oid <- oids, into: "", do: <<oid :: uint32>>
     len = <<div(byte_size(oids), 4) :: int16>>
     {?P, [name, 0, query, 0, len, oids]}
   end
@@ -265,7 +265,7 @@ defmodule Postgrex.Messages do
 
   defp decode_row_field(rest) do
     {name, rest} = decode_string(rest)
-    <<table_oid :: int32, column :: int16, type_oid :: int32,
+    <<table_oid :: uint32, column :: int16, type_oid :: uint32,
        type_size :: int16, type_mod :: int32, format :: int16,
        rest :: binary>> = rest
     field = row_field(name: name, table_oid: table_oid, column: column, type_oid: type_oid,

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -169,6 +169,14 @@ defmodule QueryTest do
     assert [{551}] = query("select '+(integer,integer)'::regoperator;", [])
     assert [{1247}] = query("select 'pg_type'::regclass;", [])
     assert [{23}] = query("select 'int4'::regtype;", [])
+
+    # xid type
+    assert [{xmin, xmax}] = query("select xmin, xmax from pg_type limit 1;", [])
+    assert is_number(xmin) and is_number(xmax)
+
+    # cid type
+    assert [{cmin, cmax}] = query("select cmin, cmax from pg_type limit 1;", [])
+    assert is_number(cmin) and is_number(cmax)
   end
 
   test "encode oid and its aliases", context do
@@ -193,6 +201,11 @@ defmodule QueryTest do
     assert [{551}] = query("select $1::text::regoperator;", ["+(integer,integer)"])
     assert [{1247}] = query("select $1::text::regclass;", ["pg_type"])
     assert [{23}] = query("select $1::text::regtype;", ["int4"])
+  end
+
+  test "tuple ids", context do
+    assert [{tid}] = query("select ctid from pg_type limit 1;", [])
+    assert [{{5, 10}}] = query("select $1::tid;", [{5, 10}])
   end
 
   test "encoding oids as binary fails with a helpful error message", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -195,6 +195,11 @@ defmodule QueryTest do
     assert [{23}] = query("select $1::text::regtype;", ["int4"])
   end
 
+  test "encoding oids as binary fails with a helpful error message", context do
+    assert %Postgrex.Error{message: message} = catch_error(query("select $1::regclass;", ["pg_type"]))
+    assert message =~ "See https://github.com/ericmj/postgrex#oid-type-encoding"
+  end
+
   test "encode basic types", context do
     assert [{nil, nil}] = query("SELECT $1::text, $2::int", [nil, nil])
     assert [{true, false}] = query("SELECT $1::bool, $2::bool", [true, false])


### PR DESCRIPTION
Fixes #63

I noticed that there are a few places where oid is treated as int32 not as uint32. I can fix that in a separate PR.