### PR TITLE
Fix numeric encoding for fractional numbers with less digits than numeric_base.

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -37,6 +37,7 @@ defmodule QueryTest do
   test "decode numeric", context do
     assert [{Decimal.new("42")}] == query("SELECT 42::numeric", [])
     assert [{Decimal.new("42.0000000000")}] == query("SELECT 42.0::numeric(100, 10)", [])
+    assert [{Decimal.new("1.001")}] == query("SELECT 1.001", [])
     assert [{Decimal.new("0.4242")}] == query("SELECT 0.4242", [])
     assert [{Decimal.new("42.4242")}] == query("SELECT 42.4242", [])
     assert [{Decimal.new("12345.12345")}] == query("SELECT 12345.12345", [])
@@ -228,9 +229,8 @@ defmodule QueryTest do
 
   test "encode numeric", context do
     nums = [
-      "42",
-      "0.4242",
-      "42.4242",
+      "1.001",
+      "0.01",
       "0.00012345",
       "1000000000",
       "1000000000.0",


### PR DESCRIPTION
Referencing this [PR](https://github.com/ericmj/postgrex/pull/66) and [elixir-lang/ecto#547](https://github.com/elixir-lang/ecto/issues/547) issue.

We've found out that the problem was related with the float's padding, but we're not sure it is the proper fix. What do you think?