### PR TITLE
Refactor Connection.query!/4 and Connection.unlisten!/3

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -110,15 +110,9 @@ defmodule Postgrex.Connection do
   """
   @spec query!(pid, iodata, list, Keyword.t) :: Postgrex.Result.t
   def query!(pid, statement, params, opts \\ []) do
-    message = {:query, statement, params}
-    timeout = opts[:timeout] || @timeout
-    case GenServer.call(pid, message, timeout) do
-      %Postgrex.Result{} = res ->
-        res
-      %Postgrex.Error{} = err ->
-        raise err
-      {:error, kind, reason, stack} ->
-        :erlang.raise(kind, reason, stack)
+    case query(pid, statement, params, opts) do
+      {:ok, res}    -> res
+      {:error, err} -> raise err
     end
   end
 
@@ -179,12 +173,9 @@ defmodule Postgrex.Connection do
   """
   @spec unlisten!(pid, reference, Keyword.t) :: :ok
   def unlisten!(pid, ref, opts \\ []) do
-    message = {:unlisten, ref}
-    timeout = opts[:timeout] || @timeout
-    case GenServer.call(pid, message, timeout) do
-      :ok -> :ok
-      %ArgumentError{} = err -> raise err
-      %Postgrex.Error{} = err -> raise err
+    case unlisten(pid, ref, opts) do
+      :ok           -> :ok
+      {:error, err} -> raise err
     end
   end
 


### PR DESCRIPTION
Both those function basically replicated the behaviour of their non-bang counterparts.

I'm not sure this was an intended behaviour, and if it was I can only imagine it was for performance (I may be completely wrong :smiley:). Not building on top of the non-bang version duplicates a lot of code (almost all code in the functions) and is therefore slightly hard to read and more error prone.

This commit builds those functions on top of their non-bang counterparts. Let me know what you think!