### PR TITLE
Build Connection.listen!/3 on top of Connection.listen/3

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -140,11 +140,9 @@ defmodule Postgrex.Connection do
   """
   @spec listen!(pid, String.t, Keyword.t) :: reference
   def listen!(pid, channel, opts \\ []) do
-    message = {:listen, channel, self()}
-    timeout = opts[:timeout] || @timeout
-    case GenServer.call(pid, message, timeout) do
-      ref when is_reference(ref)  -> ref
-      %Postgrex.Error{} = err     -> raise err
+    case listen(pid, channel, opts) do
+      {:ok, ref}    -> ref
+      {:error, err} -> raise err
     end
   end
 


### PR DESCRIPTION
Completely skipped `Postgrex.Connection.listen(!)/3` in the last PR (#70). Sorry :|