### PR TITLE
Use `to_char_list/1` when possible

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -233,8 +233,7 @@ defmodule Postgrex.Connection do
 
   @doc false
   def handle_cast(:connect, %{queue: queue, opts: opts} = s) do
-    host       = Keyword.fetch!(opts, :hostname)
-    host       = if is_binary(host), do: String.to_char_list(host), else: host
+    host       = Keyword.fetch!(opts, :hostname) |> to_char_list
     port       = opts[:port] || 5432
     timeout    = opts[:timeout] || @timeout
     sock_opts  = [{:active, :once}, {:packet, :raw}, :binary] ++ (opts[:socket_options] || [])


### PR DESCRIPTION
Instead of checking if the hostname that we pass to `:gen_tcp.connect/3` is a binary and converting it to a charlist if it is (`String.to_char_list/1`), we can call `to_char_list/1` which converts anything to a charlist according to the `List.Chars` protocol.

Avoiding `to_char_list/1` may have been intentional though; if this is the case, feel free to close this PR (and maybe explain to me the reason behind this choice so that I can learn something myself :)).