### PR TITLE
Improved support of hstore for case when hstore extension is created inside a PG schema

### DIFF
--- a/lib/postgrex/extensions/binary.ex
+++ b/lib/postgrex/extensions/binary.ex
@@ -123,7 +123,7 @@ defmodule Postgrex.Extensions.Binary do
     do: encode_range(range, oid, types)
   def encode(%TypeInfo{send: "tidsend"}, {block, tuple}, _, _),
     do: <<block :: uint32, tuple :: uint16>>
-  def encode(%TypeInfo{send: "hstore_send"}, map, _, _),
+  def encode(%TypeInfo{type: "hstore"}, map, _, _),
     do: encode_hstore(map)
 
   # Define encodings for all oid types
@@ -435,7 +435,7 @@ defmodule Postgrex.Extensions.Binary do
     do: decode_range(bin, oid, types)
   def decode(%TypeInfo{send: "tidsend"}, <<block :: uint32, tuple :: uint16>>, _, _),
     do: {block, tuple}
-  def decode(%TypeInfo{send: "hstore_send"}, bin, _, _),
+  def decode(%TypeInfo{type: "hstore"}, bin, _, _),
     do: decode_hstore(bin)
 
   # Define decodings for all oid types


### PR DESCRIPTION
Assume we have hstore extension created in such the way:
 `CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA test;`
So we will get the following type info:
``` elixir
%Postgrex.TypeInfo{
  array_elem: 0, 
  base_type: 0, 
  comp_elems: [], 
  input: "test.hstore_in", 
  oid: 21066, 
  output: "test.hstore_out", 
  receive: "test.hstore_recv", 
  send: "test.hstore_send", 
  type: "hstore"
}
```

B/c of schema name is not a constant, only type field could be matched for sure.