### PR TITLE
Improved support of hstore for case when hstore extension is created inside a PG schema

### DIFF
--- a/lib/postgrex/extensions/binary.ex
+++ b/lib/postgrex/extensions/binary.ex
@@ -38,7 +38,7 @@ defmodule Postgrex.Extensions.Binary do
               int2send int4send int8send float4send float8send numeric_send
               uuid_send date_send time_send timetz_send timestamp_send
               timestamptz_send interval_send enum_send tidsend unknownsend
-              hstore_send) ++ @oid_senders
+              ) ++ @oid_senders
 
   def init(parameters, _opts),
     do: parameters["server_version"] |> Postgrex.Utils.parse_version
@@ -47,7 +47,7 @@ defmodule Postgrex.Extensions.Binary do
     do: [send: "void_send"] ++ matching(0)
 
   def matching(_),
-    do: unquote(Enum.map(@senders, &{:send, &1}))
+    do: unquote([type: "hstore"] ++ Enum.map(@senders, &{:send, &1}))
 
   def format(_),
     do: :binary
@@ -123,7 +123,7 @@ defmodule Postgrex.Extensions.Binary do
     do: encode_range(range, oid, types)
   def encode(%TypeInfo{send: "tidsend"}, {block, tuple}, _, _),
     do: <<block :: uint32, tuple :: uint16>>
-  def encode(%TypeInfo{send: "hstore_send"}, map, _, _),
+  def encode(%TypeInfo{type: "hstore"}, map, _, _),
     do: encode_hstore(map)
 
   # Define encodings for all oid types
@@ -435,7 +435,7 @@ defmodule Postgrex.Extensions.Binary do
     do: decode_range(bin, oid, types)
   def decode(%TypeInfo{send: "tidsend"}, <<block :: uint32, tuple :: uint16>>, _, _),
     do: {block, tuple}
-  def decode(%TypeInfo{send: "hstore_send"}, bin, _, _),
+  def decode(%TypeInfo{type: "hstore"}, bin, _, _),
     do: decode_hstore(bin)
 
   # Define decodings for all oid types

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -1,4 +1,4 @@
-defmodule CustomExtensions do
+defmodule CustomExtensionsTest do
   use ExUnit.Case, async: true
   import Postgrex.TestHelper
   alias Postgrex.Connection, as: P

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -1,0 +1,28 @@
+defmodule SchemaTest do
+  use ExUnit.Case, async: true
+  import Postgrex.TestHelper
+  alias Postgrex.Connection, as: P
+
+  setup do
+    opts = [ database: "postgrex_test_with_schemas" ]
+    {:ok, pid} = P.start_link(opts)
+    {:ok, [pid: pid]}
+  end
+
+
+  @tag min_pg_version: "9.1"
+  test "encode hstore", context do
+    assert [{%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}}] =
+           query ~s(SELECT $1::test.hstore), [%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}]
+  end
+
+  @tag min_pg_version: "9.1"
+  test "decode hstore inside a schema", context do
+    assert [{%{}}] = query(~s{SELECT ''::test.hstore}, [])
+    assert [{%{"Bubbles" => "7", "Name" => "Frank"}}] = query(~s{SELECT '"Name" => "Frank", "Bubbles" => "7"'::test.hstore}, [])
+    assert [{%{"non_existant" => nil, "present" => "&accounted_for"}}] = query(~s{SELECT '"non_existant" => NULL, "present" => "&accounted_for"'::test.hstore}, [])
+    assert [{%{"spaces in the key" => "are easy!", "floats too" => "66.6"}}] = query(~s{SELECT '"spaces in the key" => "are easy!", "floats too" => "66.6"'::test.hstore}, [])
+    assert [{%{"this is true" => "true", "though not this" => "false"}}] = query(~s{SELECT '"this is true" => "true", "though not this" => "false"'::test.hstore}, [])
+  end
+
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,10 +47,18 @@ DROP TYPE IF EXISTS enum1;
 CREATE TYPE enum1 AS ENUM ('elixir', 'erlang');
 """
 
+sql_with_schemas = """
+DROP SCHEMA IF EXISTS test;
+CREATE SCHEMA test;
+"""
+
 cmds = [
   ~s(psql -U postgres -c "DROP DATABASE IF EXISTS postgrex_test;"),
+  ~s(psql -U postgres -c "DROP DATABASE IF EXISTS postgrex_test_with_schemas;"),
   ~s(psql -U postgres -c "CREATE DATABASE postgrex_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"),
-  ~s(psql -U postgres -d postgrex_test -c "#{sql}")
+  ~s(psql -U postgres -c "CREATE DATABASE postgrex_test_with_schemas TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';"),
+  ~s(psql -U postgres -d postgrex_test -c "#{sql}"),
+  ~s(psql -U postgres -d postgrex_test_with_schemas -c "#{sql_with_schemas}")
 ]
 
 pg_version = System.get_env("PGVERSION")
@@ -59,7 +67,8 @@ pg_path = System.get_env("PGPATH")
 cmds =
   cond do
     !pg_version || String.to_float(pg_version) >= 9.1 ->
-      cmds ++ [~s(psql -U postgres -d postgrex_test -c "CREATE EXTENSION IF NOT EXISTS hstore;")]
+      cmds ++ [~s(psql -U postgres -d postgrex_test_with_schemas -c "CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA test;"),
+               ~s(psql -U postgres -d postgrex_test -c "CREATE EXTENSION IF NOT EXISTS hstore;")]
     String.to_float(pg_version) == 9.0 ->
       cmds ++ [~s(psql -U postgres -d postgrex_test -f "#{pg_path}/contrib/hstore.sql")]
     true ->


### PR DESCRIPTION
I've tried to remove schema prefix for TypeInfo fields in Types.build_types/1. But it looks like a strange hack and could lead to side-effects besides.
And in any case it won't be enough.
Types are preloaded with Types.bootstrap_query/2, which also use send matchers in SQL query like 
``` sql
SELECT t.oid, t.typname, t.typsend, t.typreceive, t.typoutput, t.typinput,
       t.typelem, coalesce(r.rngsubtype, 0), ARRAY (
  SELECT a.atttypid
  FROM pg_attribute AS a
  WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped
  ORDER BY a.attnum
)
FROM pg_type AS t
LEFT JOIN pg_range AS r ON r.rngtypid = t.oid
WHERE
  t.typname::text = ANY ((ARRAY[])::text[]) OR
  t.typsend::text = ANY ((ARRAY['array_send', 'range_send', 'record_send', 'cidsend', 'xidsend', 'regtypesend', 'regclasssend', 'regoperatorsend', 'regopersend', 'regproceduresend', 'regprocsend', 'oidsend', 'hstore_send', 'unknownsend', 'tidsend', 'enum_send', 'interval_send', 'timestamptz_send', 'timestamp_send', 'timetz_send', 'time_send', 'date_send', 'uuid_send', 'numeric_send', 'float8send', 'float4send', 'int8send', 'int4send', 'int2send', 'byteasend', 'varcharsend', 'citextsend', 'textsend', 'bpcharsend', 'boolsend', 'void_send'])::text[]) OR
  t.typreceive::text = ANY ((ARRAY[])::text[]) OR
  t.typoutput::text = ANY ((ARRAY[])::text[]) OR
  t.typinput::text = ANY ((ARRAY[])::text[])
``` 

I think, we should admit, that hstore could not be matched by typsend, else we will end up with ugly hacks like removing schema from t.typsend::text directly in SQL.
This pull request eliminates need in writing own Postgrex extension for custom hstore.