### PR TITLE
Store types in ETS and move processing to clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ After you are done, run `mix deps.get` in your shell to fetch and compile Postgr
 iex> {:ok, pid} = Postgrex.Connection.start_link(hostname: "localhost", username: "postgres", password: "postgres", database: "postgres")
 {:ok, #PID<0.69.0>}
 iex> Postgrex.Connection.query!(pid, "SELECT user_id, text FROM comments", [])
-%Postgrex.Result{command: :select, empty?: false, columns: ["user_id", "text"], rows: [{3,"hey"},{4,"there"}], size: 2}}
+%Postgrex.Result{command: :select, empty?: false, columns: ["user_id", "text"], rows: [[3,"hey"],[4,"there"]], size: 2}}
 iex> Postgrex.Connection.query!(pid, "INSERT INTO comments (user_id, text) VALUES (10, 'heya')", [])
 %Postgrex.Result{command: :insert, columns: nil, rows: nil, num_rows: 1}}
 

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -1,0 +1,13 @@
+defmodule Postgrex do
+  @moduledoc """
+  PostgreSQL driver for Elixir.
+  """
+
+  use Application
+
+  def start(_, _) do
+    import Supervisor.Spec
+    opts = [strategy: :one_for_one, name: Postgrex.Supervisor]
+    Supervisor.start_link([worker(Postgrex.TypeServer, [])], opts)
+  end
+end

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -179,6 +179,13 @@ defmodule Postgrex.Connection do
     GenServer.call(pid, :parameters, opts[:timeout] || @timeout)
   end
 
+  @doc """
+  Force the connection to reload all type information.
+
+  ## Options
+
+    * `:timeout` - Call timeout (default: `#{@timeout}`)
+  """
   def rebootstrap(pid, opts \\ []) do
     GenServer.call(pid, :rebootstrap, opts[:timeout] || @timeout)
   end
@@ -390,13 +397,7 @@ defmodule Postgrex.Connection do
   end
 
   defp command(:rebootstrap, s) do
-    s = %{s | bootstrap: true}
-    {extensions, extension_opts} = s.extensions
-
-    matchers = Types.extension_matchers(extensions, extension_opts)
-    version = s.parameters["server_version"] |> parse_version
-    query = Types.bootstrap_query(matchers, version)
-    new_query(query, [], s)
+    Protocol.bootstrap(s)
   end
 
   defp new_data(<<type :: int8, size :: int32, data :: binary>> = tail, %{state: state} = s) do

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -85,7 +85,7 @@ defmodule Postgrex.Connection do
     timeout = opts[:timeout] || @timeout
     case GenServer.call(pid, message, timeout) do
       %Postgrex.Result{} = res ->
-        {:ok, res}
+        {:ok, decode(res)}
       %Postgrex.Error{} = err ->
         {:error, err}
       {:error, kind, reason, stack} ->
@@ -176,6 +176,38 @@ defmodule Postgrex.Connection do
   @spec parameters(pid, Keyword.t) :: map
   def parameters(pid, opts \\ []) do
     GenServer.call(pid, :parameters, opts[:timeout] || @timeout)
+  end
+
+  @doc """
+  Decodes a result set.
+
+  It is a no-op if the result was already decoded.
+  """
+  def decode(%Postgrex.Result{decoder: :done} = result) do
+    result
+  end
+
+  def decode(%Postgrex.Result{} = result) do
+    %{rows: rows, decoder: {col_oids, types}} = result
+    col_oids = List.to_tuple(col_oids)
+
+    rows =
+      Enum.reduce(rows, [], fn values, acc ->
+        {_, row} =
+          Enum.reduce(values, {0, []}, fn
+            nil, {count, list} ->
+              {count + 1, [nil|list]}
+            bin, {count, list} ->
+              oid = elem(col_oids, count)
+              decoded = Postgrex.Types.decode(oid, bin, types)
+              {count + 1, [decoded|list]}
+          end)
+
+        row = Enum.reverse(row) |> List.to_tuple
+        [row|acc]
+      end)
+
+    %{result | decoder: :done, rows: rows}
   end
 
   ### GEN_SERVER CALLBACKS ###

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -6,7 +6,6 @@ defmodule Postgrex.Connection do
   use GenServer
   alias Postgrex.Protocol
   alias Postgrex.Messages
-  alias Postgrex.Types
   import Postgrex.BinaryUtils
   import Postgrex.Utils
 

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -202,9 +202,7 @@ defmodule Postgrex.Connection do
               decoded = Postgrex.Types.decode(oid, bin, types)
               {count + 1, [decoded|list]}
           end)
-
-        row = Enum.reverse(row) |> List.to_tuple
-        [row|acc]
+        [Enum.reverse(row)|acc]
       end)
 
     %{result | decoder: :done, rows: rows}

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -31,7 +31,7 @@ defmodule Postgrex.Protocol do
   end
 
   def bootstrap(s) do
-    case Postgrex.TypeServer.fetch(self(), s.types_key) do
+    case Postgrex.TypeServer.fetch(s.types_key) do
       {:ok, table} ->
         queue = :queue.drop(s.queue)
         Connection.next(%{s | queue: queue, state: :ready, types: table})

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -8,13 +8,15 @@ defmodule Postgrex.Result do
     * `rows` - The result set. A list of tuples, each tuple corresponding to a
                row, each element in the tuple corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
+    * `decoder` - Terms used to decode the query in the client;
   """
 
   @type t :: %__MODULE__{
     command:  atom,
     columns:  [String.t] | nil,
     rows:     [tuple] | nil,
-    num_rows: integer}
+    num_rows: integer,
+    decoder:  {term, term} | :done}
 
-  defstruct [:command, :columns, :rows, :num_rows]
+  defstruct [:command, :columns, :rows, :num_rows, :decoder]
 end

--- a/lib/postgrex/type_server.ex
+++ b/lib/postgrex/type_server.ex
@@ -1,0 +1,134 @@
+defmodule Postgrex.TypeServer do
+  @moduledoc false
+
+  use GenServer
+
+  @name  __MODULE__
+  @table :postgrex_type_server
+  @type  table :: :ets.tab
+
+  @doc """
+  Starts the type server.
+  """
+  @spec start_link :: GenServer.on_start
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: @name)
+  end
+
+  @doc """
+  Fetches the cached type entry for the given pid.
+
+  If one does not exist, we attempt to achieve a lock on key
+  for fetching the entries. If another process got the lock,
+  we wait until the entries are available or the other process
+  crashes.
+  """
+  @spec fetch(pid, key :: term) :: {:ok, table} | {:lock, reference, table}
+  def fetch(pid, key) do
+    case :ets.lookup(@table, pid) do
+      [table] -> {:ok, table}
+      []      -> GenServer.call(@name, {:fetch, pid, key}, :infinity)
+    end
+  end
+
+  @doc """
+  Unlocks the given reference for a given key after types are loaded.
+  """
+  @spec unlock(reference) :: :ok | :error
+  def unlock(ref) do
+    GenServer.call(@name, {:unlock, ref})
+  end
+
+  ## Callbacks
+
+  def init([]) do
+    :ets.new(@table, [:set, :named_table, :protected, read_concurrency: true])
+    {:ok, {%{}, HashDict.new}}
+  end
+
+  def handle_call({:fetch, pid, key}, from, {tables, conns}) do
+    case Map.get(tables, key, :missing) do
+      {:ready, refs, table} ->
+        {ref, conns} = add_connection(pid, key, table, conns)
+        tables = Map.put(tables, key, {:ready, [ref|refs], table})
+        {:reply, {:ok, table}, {tables, conns}}
+
+      {:waiting, owner_ref, waiting, table} ->
+        {ref, conns} = add_connection(pid, key, table, conns)
+        tables = Map.put(tables, key, {:waiting, owner_ref, [{ref, from}|waiting], table})
+        {:noreply, {tables, conns}}
+
+      :missing ->
+        table = :ets.new(:postgrex_type_conn, [:set, :public, read_concurrency: true])
+        {ref, conns} = add_connection(pid, key, table, conns)
+        tables = Map.put(tables, key, {:waiting, ref, [], table})
+        {:reply, {:lock, ref, table}, {tables, conns}}
+    end
+  end
+
+  def handle_call({:unlock, ref}, _from, {tables, conns}) do
+    case HashDict.get(conns, ref, :missing) do
+      {_pid, key} ->
+        {:waiting, ^ref, waiting, table} = Map.fetch!(tables, key)
+
+        refs =
+          for {waiting_ref, from} <- waiting do
+            GenServer.reply(from, {:ok, table})
+            waiting_ref
+          end
+
+        tables = Map.put(tables, key, {:ready, [ref|refs], table})
+        {:reply, :ok, {tables, conns}}
+
+      :missing ->
+        {:reply, :error, {tables, conns}}
+    end
+  end
+
+  def handle_info({:DOWN, ref, _, _, _}, {tables, conns}) do
+    {{pid, key}, conns} = HashDict.pop(conns, ref)
+    :ets.delete(@table, pid)
+
+    tables =
+      case Map.fetch!(tables, key) do
+        # There will be no one left using the table
+        {:ready, [^ref], table} ->
+          :ets.delete(table)
+          Map.delete(tables, key)
+
+        # Others are using the table
+        {:ready, refs, table} ->
+          Map.put(tables, key, {:ready, List.delete(refs, ref), table})
+
+        # The process responsible for creating the table crashed
+        # and no one else is interested on it
+        {:waiting, ^ref, [], table} ->
+          :ets.delete(table)
+          Map.delete(tables, key)
+
+        # The process responsible for creating the table crashed
+        # and others are waiting
+        {:waiting, ^ref, [{owner_ref, from}|waiting], table} ->
+          GenServer.reply(from, {:lock, owner_ref, table})
+          Map.put(tables, key, {:waiting, owner_ref, waiting, table})
+
+        # One process in the waiting list crashed
+        {:waiting, owner_ref, waiting, table} ->
+          waiting = Keyword.delete(waiting, ref)
+          Map.put(tables, key, {:waiting, owner_ref, waiting, table})
+      end
+
+    {:noreply, {tables, conns}}
+  end
+
+  def handle_info(_other, state) do
+    {:noreply, state}
+  end
+
+  defp add_connection(pid, key, table, conns) do
+    ref   = Process.monitor(pid)
+    conns = HashDict.put(conns, ref, {pid, key})
+    :ets.insert(@table, {pid, table})
+    {ref, conns}
+  end
+end

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -15,7 +15,7 @@ defmodule Postgrex.Types do
   @typedoc """
   State used by the encoder/decoder functions
   """
-  @opaque state :: {HashDict.t, HashDict.t}
+  @opaque state :: :ets.tab
 
   @higher_types ["array_send", "range_send", "record_send"]
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,9 @@ defmodule Postgrex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger], mod: {Postgrex, []}]
+    [applications: [:logger],
+     mod: {Postgrex, []},
+     env: [type_server_reap_after: 3 * 60_000]]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Postgrex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger]]
+    [applications: [:logger], mod: {Postgrex, []}]
   end
 
   defp deps do

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -50,16 +50,16 @@ defmodule CustomExtensionsTest do
   end
 
   test "encode and decode", context do
-    assert [{44}] = query("SELECT $1::int4", [42])
-    assert [{[44]}] = query("SELECT $1::int4[]", [[42]])
+    assert [[44]] = query("SELECT $1::int4", [42])
+    assert [[[44]]] = query("SELECT $1::int4[]", [[42]])
   end
 
   test "encode and decode unknown type", context do
-    assert [{"23"}] =
+    assert [["23"]] =
            query("SELECT $1::oid", ["23"])
   end
 
   test "dont decode text format", context do
-    assert [{"123.45"}] = query("SELECT 123.45::float8", [])
+    assert [["123.45"]] = query("SELECT 123.45::float8", [])
   end
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -78,6 +78,11 @@ defmodule LoginTest do
     opts = [ database: "postgrex_test" ]
     assert {:ok, pid} = P.start_link(opts)
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+
+    assert {:ok, pid} = P.start_link(opts)
+    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
+
+
     assert :ok = P.stop(pid)
   end
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -78,11 +78,6 @@ defmodule LoginTest do
     opts = [ database: "postgrex_test" ]
     assert {:ok, pid} = P.start_link(opts)
     assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
-
-    assert {:ok, pid} = P.start_link(opts)
-    assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
-
-
     assert :ok = P.stop(pid)
   end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -10,197 +10,197 @@ defmodule QueryTest do
   end
 
   test "iodata", context do
-    assert [{123}] = query(["S", ?E, ["LEC"|"T"], " ", '123'], [])
+    assert [[123]] = query(["S", ?E, ["LEC"|"T"], " ", '123'], [])
   end
 
   test "decode basic types", context do
-    assert [{nil}] = query("SELECT NULL", [])
-    assert [{true, false}] = query("SELECT true, false", [])
-    assert [{"e"}] = query("SELECT 'e'::char", [])
-    assert [{"ẽ"}] = query("SELECT 'ẽ'::char", [])
-    assert [{42}] = query("SELECT 42", [])
-    assert [{42.0}] = query("SELECT 42::float", [])
-    assert [{:NaN}] = query("SELECT 'NaN'::float", [])
-    assert [{:inf}] = query("SELECT 'inf'::float", [])
-    assert [{:"-inf"}] = query("SELECT '-inf'::float", [])
-    assert [{"ẽric"}] = query("SELECT 'ẽric'", [])
-    assert [{"ẽric"}] = query("SELECT 'ẽric'::varchar", [])
-    assert [{<<1, 2, 3>>}] = query("SELECT '\\001\\002\\003'::bytea", [])
+    assert [[nil]] = query("SELECT NULL", [])
+    assert [[true, false]] = query("SELECT true, false", [])
+    assert [["e"]] = query("SELECT 'e'::char", [])
+    assert [["ẽ"]] = query("SELECT 'ẽ'::char", [])
+    assert [[42]] = query("SELECT 42", [])
+    assert [[42.0]] = query("SELECT 42::float", [])
+    assert [[:NaN]] = query("SELECT 'NaN'::float", [])
+    assert [[:inf]] = query("SELECT 'inf'::float", [])
+    assert [[:"-inf"]] = query("SELECT '-inf'::float", [])
+    assert [["ẽric"]] = query("SELECT 'ẽric'", [])
+    assert [["ẽric"]] = query("SELECT 'ẽric'::varchar", [])
+    assert [[<<1, 2, 3>>]] = query("SELECT '\\001\\002\\003'::bytea", [])
   end
 
   test "decode numeric", context do
-    assert [{Decimal.new("42")}] == query("SELECT 42::numeric", [])
-    assert [{Decimal.new("42.0000000000")}] == query("SELECT 42.0::numeric(100, 10)", [])
-    assert [{Decimal.new("1.001")}] == query("SELECT 1.001", [])
-    assert [{Decimal.new("0.4242")}] == query("SELECT 0.4242", [])
-    assert [{Decimal.new("42.4242")}] == query("SELECT 42.4242", [])
-    assert [{Decimal.new("12345.12345")}] == query("SELECT 12345.12345", [])
-    assert [{Decimal.new("0.00012345")}] == query("SELECT 0.00012345", [])
-    assert [{Decimal.new("1000000000.0")}] == query("SELECT 1000000000.0", [])
-    assert [{Decimal.new("1000000000.1")}] == query("SELECT 1000000000.1", [])
-    assert [{Decimal.new("123456789123456789123456789")}] == query("SELECT 123456789123456789123456789::numeric", [])
-    assert [{Decimal.new("123456789123456789123456789.123456789")}] == query("SELECT 123456789123456789123456789.123456789", [])
-    assert [{Decimal.new("1.1234500000")}] == query("SELECT 1.1234500000", [])
-    assert [{Decimal.new("NaN")}] == query("SELECT 'NaN'::numeric", [])
+    assert [[Decimal.new("42")]] == query("SELECT 42::numeric", [])
+    assert [[Decimal.new("42.0000000000")]] == query("SELECT 42.0::numeric(100, 10)", [])
+    assert [[Decimal.new("1.001")]] == query("SELECT 1.001", [])
+    assert [[Decimal.new("0.4242")]] == query("SELECT 0.4242", [])
+    assert [[Decimal.new("42.4242")]] == query("SELECT 42.4242", [])
+    assert [[Decimal.new("12345.12345")]] == query("SELECT 12345.12345", [])
+    assert [[Decimal.new("0.00012345")]] == query("SELECT 0.00012345", [])
+    assert [[Decimal.new("1000000000.0")]] == query("SELECT 1000000000.0", [])
+    assert [[Decimal.new("1000000000.1")]] == query("SELECT 1000000000.1", [])
+    assert [[Decimal.new("123456789123456789123456789")]] == query("SELECT 123456789123456789123456789::numeric", [])
+    assert [[Decimal.new("123456789123456789123456789.123456789")]] == query("SELECT 123456789123456789123456789.123456789", [])
+    assert [[Decimal.new("1.1234500000")]] == query("SELECT 1.1234500000", [])
+    assert [[Decimal.new("NaN")]] == query("SELECT 'NaN'::numeric", [])
   end
 
   test "decode uuid", context do
     uuid = <<160,238,188,153,156,11,78,248,187,109,107,185,189,56,10,17>>
-    assert [{^uuid}] = query("SELECT 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid", [])
+    assert [[^uuid]] = query("SELECT 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid", [])
   end
 
   test "decode arrays", context do
-    assert [{[]}] = query("SELECT ARRAY[]::integer[]", [])
-    assert [{[1]}] = query("SELECT ARRAY[1]", [])
-    assert [{[1,2]}] = query("SELECT ARRAY[1,2]", [])
-    assert [{[[0],[1]]}] = query("SELECT ARRAY[[0],[1]]", [])
-    assert [{[[0]]}] = query("SELECT ARRAY[ARRAY[0]]", [])
+    assert [[[]]] = query("SELECT ARRAY[]::integer[]", [])
+    assert [[[1]]] = query("SELECT ARRAY[1]", [])
+    assert [[[1,2]]] = query("SELECT ARRAY[1,2]", [])
+    assert [[[[0],[1]]]] = query("SELECT ARRAY[[0],[1]]", [])
+    assert [[[[0]]]] = query("SELECT ARRAY[ARRAY[0]]", [])
   end
 
   test "decode time", context do
-    assert [{%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 0}}] =
+    assert [[%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 0}]] =
            query("SELECT time '00:00:00'", [])
-    assert [{%Postgrex.Time{hour: 1, min: 2, sec: 3, usec: 0}}] =
+    assert [[%Postgrex.Time{hour: 1, min: 2, sec: 3, usec: 0}]] =
            query("SELECT time '01:02:03'", [])
-    assert [{%Postgrex.Time{hour: 23, min: 59, sec: 59, usec: 0}}] =
+    assert [[%Postgrex.Time{hour: 23, min: 59, sec: 59, usec: 0}]] =
            query("SELECT time '23:59:59'", [])
-    assert [{%Postgrex.Time{hour: 4, min: 5, sec: 6, usec: 0}}] =
+    assert [[%Postgrex.Time{hour: 4, min: 5, sec: 6, usec: 0}]] =
            query("SELECT time '04:05:06 PST'", [])
 
-    assert [{%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 123000}}] =
+    assert [[%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 123000}]] =
            query("SELECT time '00:00:00.123'", [])
-    assert [{%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 123456}}] =
+    assert [[%Postgrex.Time{hour: 0, min: 0, sec: 0, usec: 123456}]] =
            query("SELECT time '00:00:00.123456'", [])
-    assert [{%Postgrex.Time{hour: 1, min: 2, sec: 3, usec: 123456}}] =
+    assert [[%Postgrex.Time{hour: 1, min: 2, sec: 3, usec: 123456}]] =
            query("SELECT time '01:02:03.123456'", [])
   end
 
   test "decode date", context do
-    assert [{%Postgrex.Date{year: 1, month: 1, day: 1}}] =
+    assert [[%Postgrex.Date{year: 1, month: 1, day: 1}]] =
            query("SELECT date '0001-01-01'", [])
-    assert [{%Postgrex.Date{year: 1, month: 2, day: 3}}] =
+    assert [[%Postgrex.Date{year: 1, month: 2, day: 3}]] =
            query("SELECT date '0001-02-03'", [])
-    assert [{%Postgrex.Date{year: 2013, month: 9, day: 23}}] =
+    assert [[%Postgrex.Date{year: 2013, month: 9, day: 23}]] =
            query("SELECT date '2013-09-23'", [])
   end
 
   test "decode timestamp", context do
-    assert [{%Postgrex.Timestamp{year: 2001, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 0}}] =
+    assert [[%Postgrex.Timestamp{year: 2001, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 0}]] =
            query("SELECT timestamp '2001-01-01 00:00:00'", [])
-    assert [{%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37, usec: 123000}}] =
+    assert [[%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37, usec: 123000}]] =
            query("SELECT timestamp '2013-09-23 14:04:37.123'", [])
-    assert [{%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37, usec: 0}}] =
+    assert [[%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37, usec: 0}]] =
            query("SELECT timestamp '2013-09-23 14:04:37 PST'", [])
-    assert [{%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 123456}}] =
+    assert [[%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 123456}]] =
            query("SELECT timestamp '0001-01-01 00:00:00.123456'", [])
 
   end
 
   test "decode interval", context do
-    assert [{%Postgrex.Interval{months: 0, days: 0, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0}]] =
            query("SELECT interval '0'", [])
-    assert [{%Postgrex.Interval{months: 100, days: 0, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0}]] =
            query("SELECT interval '100 months'", [])
-    assert [{%Postgrex.Interval{months: 0, days: 100, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0}]] =
            query("SELECT interval '100 days'", [])
-    assert [{%Postgrex.Interval{months: 0, days: 0, secs: 100}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100}]] =
            query("SELECT interval '100 secs'", [])
-    assert [{%Postgrex.Interval{months: 14, days: 40, secs: 10920}}] =
+    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920}]] =
            query("SELECT interval '1 year 2 months 40 days 3 hours 2 minutes'", [])
   end
 
   test "decode record", context do
-    assert [{{1, "2"}}] = query("SELECT (1, '2')::composite1", [])
-    assert [{[{1, "2"}]}] = query("SELECT ARRAY[(1, '2')::composite1]", [])
+    assert [[{1, "2"}]] = query("SELECT (1, '2')::composite1", [])
+    assert [[[{1, "2"}]]] = query("SELECT ARRAY[(1, '2')::composite1]", [])
   end
 
   test "decode enum", context do
-    assert [{"elixir"}] = query("SELECT 'elixir'::enum1", [])
+    assert [["elixir"]] = query("SELECT 'elixir'::enum1", [])
   end
 
   @tag min_pg_version: "9.2"
   test "decode range", context do
-    assert [{%Postgrex.Range{lower: 2, upper: 5, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 2, upper: 5, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT '(1,5)'::int4range", [])
-    assert [{%Postgrex.Range{lower: 1, upper: 7, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 1, upper: 7, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT '[1,6]'::int4range", [])
-    assert [{%Postgrex.Range{lower: nil, upper: 5, lower_inclusive: false, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: 5, lower_inclusive: false, upper_inclusive: false}]] =
            query("SELECT '(,5)'::int4range", [])
-    assert [{%Postgrex.Range{lower: 1, upper: nil, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 1, upper: nil, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT '[1,)'::int4range", [])
-    assert [{%Postgrex.Range{lower: nil, upper: nil, lower_inclusive: false, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: nil, lower_inclusive: false, upper_inclusive: false}]] =
            query("SELECT '(,)'::int4range", [])
-    assert [{%Postgrex.Range{lower: nil, upper: nil, lower_inclusive: false, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: nil, lower_inclusive: false, upper_inclusive: false}]] =
            query("SELECT '[,]'::int4range", [])
 
-    assert [{%Postgrex.Range{lower: 3, upper: 8, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 3, upper: 8, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT '(2,8)'::int8range", [])
 
-    assert [{%Postgrex.Range{lower: Decimal.new("1.2"), upper: Decimal.new("3.4"), lower_inclusive: false, upper_inclusive: false}}] ==
+    assert [[%Postgrex.Range{lower: Decimal.new("1.2"), upper: Decimal.new("3.4"), lower_inclusive: false, upper_inclusive: false}]] ==
            query("SELECT '(1.2,3.4)'::numrange", [])
 
-    assert [{%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}}] =
+    assert [[%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}]] =
            query("SELECT '[2014-1-1,2014-12-31)'::daterange", [])
-    assert [{%Postgrex.Range{lower: nil, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}]] =
            query("SELECT '(,2014-12-31)'::daterange", [])
-    assert [{%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 2}, upper: nil}}] =
+    assert [[%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 2}, upper: nil}]] =
            query("SELECT '(2014-1-1,]'::daterange", [])
   end
 
   test "decode oid and its aliases", context do
-    assert [{4294967295}] = query("select 4294967295::oid;", [])
+    assert [[4294967295]] = query("select 4294967295::oid;", [])
 
-    assert [{"-"}] = query("select '-'::regproc::text;", [])
-    assert [{"sum(integer)"}] = query("select 'sum(int4)'::regprocedure::text;", [])
-    assert [{"||/"}] = query("select 'pg_catalog.||/'::regoper::text;", [])
-    assert [{"+(integer,integer)"}] = query("select '+(integer,integer)'::regoperator::text;", [])
-    assert [{"pg_type"}] = query("select 'pg_type'::regclass::text;", [])
-    assert [{"integer"}] = query("select 'int4'::regtype::text;", [])
+    assert [["-"]] = query("select '-'::regproc::text;", [])
+    assert [["sum(integer)"]] = query("select 'sum(int4)'::regprocedure::text;", [])
+    assert [["||/"]] = query("select 'pg_catalog.||/'::regoper::text;", [])
+    assert [["+(integer,integer)"]] = query("select '+(integer,integer)'::regoperator::text;", [])
+    assert [["pg_type"]] = query("select 'pg_type'::regclass::text;", [])
+    assert [["integer"]] = query("select 'int4'::regtype::text;", [])
 
-    assert [{0}] = query("select '-'::regproc;", [])
-    assert [{44}] = query("select 'regprocin'::regproc;", [])
-    assert [{2108}] = query("select 'sum(int4)'::regprocedure;", [])
-    assert [{597}] = query("select 'pg_catalog.||/'::regoper;", [])
-    assert [{551}] = query("select '+(integer,integer)'::regoperator;", [])
-    assert [{1247}] = query("select 'pg_type'::regclass;", [])
-    assert [{23}] = query("select 'int4'::regtype;", [])
+    assert [[0]] = query("select '-'::regproc;", [])
+    assert [[44]] = query("select 'regprocin'::regproc;", [])
+    assert [[2108]] = query("select 'sum(int4)'::regprocedure;", [])
+    assert [[597]] = query("select 'pg_catalog.||/'::regoper;", [])
+    assert [[551]] = query("select '+(integer,integer)'::regoperator;", [])
+    assert [[1247]] = query("select 'pg_type'::regclass;", [])
+    assert [[23]] = query("select 'int4'::regtype;", [])
 
     # xid type
-    assert [{xmin, xmax}] = query("select xmin, xmax from pg_type limit 1;", [])
+    assert [[xmin, xmax]] = query("select xmin, xmax from pg_type limit 1;", [])
     assert is_number(xmin) and is_number(xmax)
 
     # cid type
-    assert [{cmin, cmax}] = query("select cmin, cmax from pg_type limit 1;", [])
+    assert [[cmin, cmax]] = query("select cmin, cmax from pg_type limit 1;", [])
     assert is_number(cmin) and is_number(cmax)
   end
 
   test "encode oid and its aliases", context do
     # oid's range is 0 to 4294967295
-    assert [{0}] = query("select $1::oid;", [0])
-    assert [{4294967295}] = query("select $1::oid;", [4294967295])
+    assert [[0]] = query("select $1::oid;", [0])
+    assert [[4294967295]] = query("select $1::oid;", [4294967295])
     assert :function_clause = catch_error(query("SELECT $1::oid", [0 - 1]))
     assert :function_clause = catch_error(query("SELECT $1::oid", [4294967295 + 1]))
 
-    assert [{"-"}] = query("select $1::regproc::text;", [0])
-    assert [{"regprocin"}] = query("select $1::regproc::text;", [44])
-    assert [{"sum(integer)"}] = query("select $1::regprocedure::text;", [2108])
-    assert [{"||/"}] = query("select $1::regoper::text;", [597])
-    assert [{"+(integer,integer)"}] = query("select $1::regoperator::text;", [551])
-    assert [{"pg_type"}] = query("select $1::regclass::text;", [1247])
-    assert [{"integer"}] = query("select $1::regtype::text;", [23])
+    assert [["-"]] = query("select $1::regproc::text;", [0])
+    assert [["regprocin"]] = query("select $1::regproc::text;", [44])
+    assert [["sum(integer)"]] = query("select $1::regprocedure::text;", [2108])
+    assert [["||/"]] = query("select $1::regoper::text;", [597])
+    assert [["+(integer,integer)"]] = query("select $1::regoperator::text;", [551])
+    assert [["pg_type"]] = query("select $1::regclass::text;", [1247])
+    assert [["integer"]] = query("select $1::regtype::text;", [23])
 
-    assert [{0}] = query("select $1::text::regproc;", ["-"])
-    assert [{44}] = query("select $1::text::regproc;", ["regprocin"])
-    assert [{2108}] = query("select $1::text::regprocedure;", ["sum(int4)"])
-    assert [{597}] = query("select $1::text::regoper;", ["pg_catalog.||/"])
-    assert [{551}] = query("select $1::text::regoperator;", ["+(integer,integer)"])
-    assert [{1247}] = query("select $1::text::regclass;", ["pg_type"])
-    assert [{23}] = query("select $1::text::regtype;", ["int4"])
+    assert [[0]] = query("select $1::text::regproc;", ["-"])
+    assert [[44]] = query("select $1::text::regproc;", ["regprocin"])
+    assert [[2108]] = query("select $1::text::regprocedure;", ["sum(int4)"])
+    assert [[597]] = query("select $1::text::regoper;", ["pg_catalog.||/"])
+    assert [[551]] = query("select $1::text::regoperator;", ["+(integer,integer)"])
+    assert [[1247]] = query("select $1::text::regclass;", ["pg_type"])
+    assert [[23]] = query("select $1::text::regtype;", ["int4"])
   end
 
   test "tuple ids", context do
-    assert [{_tid}] = query("select ctid from pg_type limit 1;", [])
-    assert [{{5, 10}}] = query("select $1::tid;", [{5, 10}])
+    assert [[_tid]] = query("select ctid from pg_type limit 1;", [])
+    assert [[{5, 10}]] = query("select $1::tid;", [{5, 10}])
   end
 
   test "encoding oids as binary fails with a helpful error message", context do
@@ -210,24 +210,24 @@ defmodule QueryTest do
 
   @tag min_pg_version: "9.0"
   test "decode hstore", context do
-    assert [{%{}}] = query(~s{SELECT ''::hstore}, [])
-    assert [{%{"Bubbles" => "7", "Name" => "Frank"}}] = query(~s{SELECT '"Name" => "Frank", "Bubbles" => "7"'::hstore}, [])
-    assert [{%{"non_existant" => nil, "present" => "&accounted_for"}}] = query(~s{SELECT '"non_existant" => NULL, "present" => "&accounted_for"'::hstore}, [])
-    assert [{%{"spaces in the key" => "are easy!", "floats too" => "66.6"}}] = query(~s{SELECT '"spaces in the key" => "are easy!", "floats too" => "66.6"'::hstore}, [])
-    assert [{%{"this is true" => "true", "though not this" => "false"}}] = query(~s{SELECT '"this is true" => "true", "though not this" => "false"'::hstore}, [])
+    assert [[%{}]] = query(~s|SELECT ''::hstore|, [])
+    assert [[%{"Bubbles" => "7", "Name" => "Frank"}]] = query(~s|SELECT '"Name" => "Frank", "Bubbles" => "7"'::hstore|, [])
+    assert [[%{"non_existant" => nil, "present" => "&accounted_for"}]] = query(~s|SELECT '"non_existant" => NULL, "present" => "&accounted_for"'::hstore|, [])
+    assert [[%{"spaces in the key" => "are easy!", "floats too" => "66.6"}]] = query(~s|SELECT '"spaces in the key" => "are easy!", "floats too" => "66.6"'::hstore|, [])
+    assert [[%{"this is true" => "true", "though not this" => "false"}]] = query(~s|SELECT '"this is true" => "true", "though not this" => "false"'::hstore|, [])
   end
 
   test "encode basic types", context do
-    assert [{nil, nil}] = query("SELECT $1::text, $2::int", [nil, nil])
-    assert [{true, false}] = query("SELECT $1::bool, $2::bool", [true, false])
-    assert [{"ẽ"}] = query("SELECT $1::char", ["ẽ"])
-    assert [{42}] = query("SELECT $1::int", [42])
-    assert [{42.0, 43.0}] = query("SELECT $1::float, $2::float", [42, 43.0])
-    assert [{:NaN}] = query("SELECT $1::float", [:NaN])
-    assert [{:inf}] = query("SELECT $1::float", [:inf])
-    assert [{:"-inf"}] = query("SELECT $1::float", [:"-inf"])
-    assert [{"ẽric"}] = query("SELECT $1::varchar", ["ẽric"])
-    assert [{<<1, 2, 3>>}] = query("SELECT $1::bytea", [<<1, 2, 3>>])
+    assert [[nil, nil]] = query("SELECT $1::text, $2::int", [nil, nil])
+    assert [[true, false]] = query("SELECT $1::bool, $2::bool", [true, false])
+    assert [["ẽ"]] = query("SELECT $1::char", ["ẽ"])
+    assert [[42]] = query("SELECT $1::int", [42])
+    assert [[42.0, 43.0]] = query("SELECT $1::float, $2::float", [42, 43.0])
+    assert [[:NaN]] = query("SELECT $1::float", [:NaN])
+    assert [[:inf]] = query("SELECT $1::float", [:inf])
+    assert [[:"-inf"]] = query("SELECT $1::float", [:"-inf"])
+    assert [["ẽric"]] = query("SELECT $1::varchar", ["ẽric"])
+    assert [[<<1, 2, 3>>]] = query("SELECT $1::bytea", [<<1, 2, 3>>])
   end
 
   test "encode numeric", context do
@@ -249,143 +249,143 @@ defmodule QueryTest do
 
     Enum.each(nums, fn num ->
       dec = Decimal.new(num)
-      assert [{dec}] == query("SELECT $1::numeric", [dec])
+      assert [[dec]] == query("SELECT $1::numeric", [dec])
     end)
   end
 
   test "encode enforces bounds on integers", context do
     # int2's range is -32768 to +32767
-    assert [{-32768}] = query("SELECT $1::int2", [-32768])
-    assert [{32767}] = query("SELECT $1::int2", [32767])
+    assert [[-32768]] = query("SELECT $1::int2", [-32768])
+    assert [[32767]] = query("SELECT $1::int2", [32767])
     assert :function_clause = catch_error(query("SELECT $1::int2", [32767 + 1]))
     assert :function_clause = catch_error(query("SELECT $1::int2", [-32768 - 1]))
 
     # int4's range is -2147483648 to +2147483647
-    assert [{-2147483648}] = query("SELECT $1::int4", [-2147483648])
-    assert [{2147483647}] = query("SELECT $1::int4", [2147483647])
+    assert [[-2147483648]] = query("SELECT $1::int4", [-2147483648])
+    assert [[2147483647]] = query("SELECT $1::int4", [2147483647])
     assert :function_clause = catch_error(query("SELECT $1::int4", [2147483647 + 1]))
     assert :function_clause = catch_error(query("SELECT $1::int4", [-2147483648 - 1]))
 
     # int8's range is  -9223372036854775808 to 9223372036854775807
-    assert [{-9223372036854775808}] = query("SELECT $1::int8", [-9223372036854775808])
-    assert [{9223372036854775807}] = query("SELECT $1::int8", [9223372036854775807])
+    assert [[-9223372036854775808]] = query("SELECT $1::int8", [-9223372036854775808])
+    assert [[9223372036854775807]] = query("SELECT $1::int8", [9223372036854775807])
     assert :function_clause = catch_error(query("SELECT $1::int8", [9223372036854775807 + 1]))
     assert :function_clause = catch_error(query("SELECT $1::int8", [-9223372036854775808 - 1]))
   end
 
   test "encode uuid", context do
     uuid = <<0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15>>
-    assert [{^uuid}] = query("SELECT $1::uuid", [uuid])
+    assert [[^uuid]] = query("SELECT $1::uuid", [uuid])
   end
 
   test "encode date", context do
-    assert [{%Postgrex.Date{year: 1, month: 1, day: 1}}] =
+    assert [[%Postgrex.Date{year: 1, month: 1, day: 1}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 1, month: 1, day: 1}])
-    assert [{%Postgrex.Date{year: 1, month: 2, day: 3}}] =
+    assert [[%Postgrex.Date{year: 1, month: 2, day: 3}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 1, month: 2, day: 3}])
-    assert [{%Postgrex.Date{year: 2013, month: 9, day: 23}}] =
+    assert [[%Postgrex.Date{year: 2013, month: 9, day: 23}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 2013, month: 9, day: 23}])
-    assert [{%Postgrex.Date{year: 1999, month: 12, day: 31}}] =
+    assert [[%Postgrex.Date{year: 1999, month: 12, day: 31}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 1999, month: 12, day: 31}])
-    assert [{%Postgrex.Date{year: 1999, month: 12, day: 31}}] =
+    assert [[%Postgrex.Date{year: 1999, month: 12, day: 31}]] =
            query("SELECT $1::date", [%Postgrex.Date{year: 1999, month: 12, day: 31}])
   end
 
   test "encode time", context do
-    assert [{%Postgrex.Time{hour: 0, min: 0, sec: 0}}] =
+    assert [[%Postgrex.Time{hour: 0, min: 0, sec: 0}]] =
            query("SELECT $1::time", [%Postgrex.Time{hour: 0, min: 0, sec: 0}])
-    assert [{%Postgrex.Time{hour: 1, min: 2, sec: 3}}] =
+    assert [[%Postgrex.Time{hour: 1, min: 2, sec: 3}]] =
            query("SELECT $1::time", [%Postgrex.Time{hour: 1, min: 2, sec: 3}])
-    assert [{%Postgrex.Time{hour: 23, min: 59, sec: 59}}] =
+    assert [[%Postgrex.Time{hour: 23, min: 59, sec: 59}]] =
            query("SELECT $1::time", [%Postgrex.Time{hour: 23, min: 59, sec: 59}])
-    assert [{%Postgrex.Time{hour: 4, min: 5, sec: 6, usec: 123456}}] =
+    assert [[%Postgrex.Time{hour: 4, min: 5, sec: 6, usec: 123456}]] =
            query("SELECT $1::time", [%Postgrex.Time{hour: 4, min: 5, sec: 6, usec: 123456}])
   end
 
   test "encode timestamp", context do
-    assert [{%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0}}] =
+    assert [[%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0}]] =
       query("SELECT $1::timestamp", [%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0}])
-    assert [{%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37}}] =
+    assert [[%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37}]] =
       query("SELECT $1::timestamp", [%Postgrex.Timestamp{year: 2013, month: 9, day: 23, hour: 14, min: 4, sec: 37}])
-    assert [{%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 123456}}] =
+    assert [[%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 123456}]] =
       query("SELECT $1::timestamp", [%Postgrex.Timestamp{year: 1, month: 1, day: 1, hour: 0, min: 0, sec: 0, usec: 123456}])
   end
 
   test "encode interval", context do
-    assert [{%Postgrex.Interval{months: 0, days: 0, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 0}]] =
            query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 0, secs: 0}])
-    assert [{%Postgrex.Interval{months: 100, days: 0, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 100, days: 0, secs: 0}]] =
            query("SELECT $1::interval", [%Postgrex.Interval{months: 100, days: 0, secs: 0}])
-    assert [{%Postgrex.Interval{months: 0, days: 100, secs: 0}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 100, secs: 0}]] =
            query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 100, secs: 0}])
-    assert [{%Postgrex.Interval{months: 0, days: 0, secs: 100}}] =
+    assert [[%Postgrex.Interval{months: 0, days: 0, secs: 100}]] =
            query("SELECT $1::interval", [%Postgrex.Interval{months: 0, days: 0, secs: 100}])
-    assert [{%Postgrex.Interval{months: 14, days: 40, secs: 10920}}] =
+    assert [[%Postgrex.Interval{months: 14, days: 40, secs: 10920}]] =
            query("SELECT $1::interval", [%Postgrex.Interval{months: 14, days: 40, secs: 10920}])
   end
 
   test "encode arrays", context do
-    assert [{[]}] = query("SELECT $1::integer[]", [[]])
-    assert [{[1]}] = query("SELECT $1::integer[]", [[1]])
-    assert [{[1,2]}] = query("SELECT $1::integer[]", [[1,2]])
-    assert [{[[0],[1]]}] = query("SELECT $1::integer[]", [[[0],[1]]])
-    assert [{[[0]]}] = query("SELECT $1::integer[]", [[[0]]])
-    assert [{[1, nil, 3]}] = query("SELECT $1::integer[]", [[1, nil, 3]])
+    assert [[[]]] = query("SELECT $1::integer[]", [[]])
+    assert [[[1]]] = query("SELECT $1::integer[]", [[1]])
+    assert [[[1,2]]] = query("SELECT $1::integer[]", [[1,2]])
+    assert [[[[0],[1]]]] = query("SELECT $1::integer[]", [[[0],[1]]])
+    assert [[[[0]]]] = query("SELECT $1::integer[]", [[[0]]])
+    assert [[[1, nil, 3]]] = query("SELECT $1::integer[]", [[1, nil, 3]])
   end
 
   test "encode record", context do
-    assert [{{1, "2"}}] = query("SELECT $1::composite1", [{1, "2"}])
-    assert [{[{1, "2"}]}] = query("SELECT $1::composite1[]", [[{1, "2"}]])
-    assert [{{1, nil, 3}}] = query("SELECT $1::composite2", [{1, nil, 3}])
+    assert [[{1, "2"}]] = query("SELECT $1::composite1", [{1, "2"}])
+    assert [[[{1, "2"}]]] = query("SELECT $1::composite1[]", [[{1, "2"}]])
+    assert [[{1, nil, 3}]] = query("SELECT $1::composite2", [{1, nil, 3}])
   end
 
   test "encode enum", context do
-    assert [{"elixir"}] = query("SELECT $1::enum1", ["elixir"])
+    assert [["elixir"]] = query("SELECT $1::enum1", ["elixir"])
   end
 
   @tag min_pg_version: "9.2"
   test "encode range", context do
-    assert [{%Postgrex.Range{lower: 1, upper: 4, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 1, upper: 4, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT $1::int4range", [%Postgrex.Range{lower: 1, upper: 3, lower_inclusive: true, upper_inclusive: true}])
-    assert [{%Postgrex.Range{lower: nil, upper: 6, lower_inclusive: false, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: 6, lower_inclusive: false, upper_inclusive: false}]] =
            query("SELECT $1::int4range", [%Postgrex.Range{lower: nil, upper: 5, lower_inclusive: false, upper_inclusive: true}])
-    assert [{%Postgrex.Range{lower: 3, upper: nil, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 3, upper: nil, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT $1::int4range", [%Postgrex.Range{lower: 3, upper: nil, lower_inclusive: true, upper_inclusive: true}])
-    assert [{%Postgrex.Range{lower: 4, upper: 5, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 4, upper: 5, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT $1::int4range", [%Postgrex.Range{lower: 3, upper: 5, lower_inclusive: false, upper_inclusive: false}])
 
-    assert [{%Postgrex.Range{lower: 1, upper: 4, lower_inclusive: true, upper_inclusive: false}}] =
+    assert [[%Postgrex.Range{lower: 1, upper: 4, lower_inclusive: true, upper_inclusive: false}]] =
            query("SELECT $1::int8range", [%Postgrex.Range{lower: 1, upper: 3, lower_inclusive: true, upper_inclusive: true}])
 
-    assert [{%Postgrex.Range{lower: Decimal.new("1.2"), upper: Decimal.new("3.4"), lower_inclusive: true, upper_inclusive: true}}] ==
+    assert [[%Postgrex.Range{lower: Decimal.new("1.2"), upper: Decimal.new("3.4"), lower_inclusive: true, upper_inclusive: true}]] ==
            query("SELECT $1::numrange", [%Postgrex.Range{lower: Decimal.new("1.2"), upper: Decimal.new("3.4"), lower_inclusive: true, upper_inclusive: true}])
 
-    assert [{%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: %Postgrex.Date{year: 2015, month: 1, day: 1}}}] =
+    assert [[%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: %Postgrex.Date{year: 2015, month: 1, day: 1}}]] =
            query("SELECT $1::daterange", [%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}])
-    assert [{%Postgrex.Range{lower: nil, upper: %Postgrex.Date{year: 2015, month: 1, day: 1}}}] =
+    assert [[%Postgrex.Range{lower: nil, upper: %Postgrex.Date{year: 2015, month: 1, day: 1}}]] =
            query("SELECT $1::daterange", [%Postgrex.Range{lower: nil, upper: %Postgrex.Date{year: 2014, month: 12, day: 31}}])
-    assert [{%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: nil}}] =
+    assert [[%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: nil}]] =
            query("SELECT $1::daterange", [%Postgrex.Range{lower: %Postgrex.Date{year: 2014, month: 1, day: 1}, upper: nil}])
   end
 
   @tag min_pg_version: "9.2"
   test "encode enforces bounds on integer ranges", context do
     # int4's range is -2147483648 to +2147483647
-    assert [{%Postgrex.Range{lower: -2147483648}}] = query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483648}])
-    assert [{%Postgrex.Range{upper: 2147483647}}] = query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483647, upper_inclusive: false}])
+    assert [[%Postgrex.Range{lower: -2147483648}]] = query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483648}])
+    assert [[%Postgrex.Range{upper: 2147483647}]] = query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483647, upper_inclusive: false}])
     assert :function_clause = catch_error(query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483649}]))
     assert :function_clause = catch_error(query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483648}]))
 
     # int8's range is -9223372036854775808 to 9223372036854775807
-    assert [{%Postgrex.Range{lower: -9223372036854775807}}] = query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775807}])
-    assert [{%Postgrex.Range{upper: 9223372036854775806}}] = query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775806, upper_inclusive: false}])
+    assert [[%Postgrex.Range{lower: -9223372036854775807}]] = query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775807}])
+    assert [[%Postgrex.Range{upper: 9223372036854775806}]] = query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775806, upper_inclusive: false}])
     assert :function_clause = catch_error(query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775809}]))
     assert :function_clause = catch_error(query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775808}]))
   end
 
   @tag min_pg_version: "9.0"
   test "encode hstore", context do
-    assert [{%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}}] =
+    assert [[%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}]] =
            query ~s(SELECT $1::hstore), [%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}]
   end
 
@@ -393,7 +393,7 @@ defmodule QueryTest do
     assert_raise ArgumentError, "nested lists must have lists with matching lengths", fn ->
       query("SELECT $1::integer[]", [[[1], [1,2]]])
     end
-    assert [{42}] = query("SELECT 42", [])
+    assert [[42]] = query("SELECT 42", [])
   end
 
   test "fail on encode wrong value", context do
@@ -403,7 +403,7 @@ defmodule QueryTest do
     assert_raise FunctionClauseError, fn ->
       query("SELECT $1::text", [4.0])
     end
-    assert [{42}] = query("SELECT 42", [])
+    assert [[42]] = query("SELECT 42", [])
   end
 
   test "non data statement", context do
@@ -426,14 +426,14 @@ defmodule QueryTest do
   test "multi row result", context do
     assert {:ok, res} = P.query(context[:pid], "VALUES (1, 2), (3, 4)", [])
     assert res.num_rows == 2
-    assert res.rows == [{1, 2}, {3, 4}]
+    assert res.rows == [[1, 2], [3, 4]]
   end
 
   test "insert", context do
     :ok = query("CREATE TABLE test (id int, text text)", [])
     [] = query("SELECT * FROM test", [])
     :ok = query("INSERT INTO test VALUES ($1, $2)", [42, "fortytwo"], [])
-    [{42, "fortytwo"}] = query("SELECT * FROM test", [])
+    [[42, "fortytwo"]] = query("SELECT * FROM test", [])
   end
 
   test "error codes are translated", context  do
@@ -442,7 +442,7 @@ defmodule QueryTest do
 
   test "connection works after failure", context do
     assert %Postgrex.Error{} = query("wat", [])
-    assert [{42}] = query("SELECT 42", [])
+    assert [[42]] = query("SELECT 42", [])
   end
 
   test "async test", context do
@@ -454,7 +454,7 @@ defmodule QueryTest do
     end)
 
      Enum.each(1..10, fn _ ->
-      assert_receive [{:void}], 1000
+      assert_receive [[:void]], 1000
     end)
   end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -9,12 +9,6 @@ defmodule QueryTest do
     {:ok, [pid: pid]}
   end
 
-  test "rebootstrap", context do
-    assert [{42}] = query("SELECT $1::int", [42])
-    P.rebootstrap(context.pid)
-    assert [{42}] = query("SELECT $1::int", [42])
-  end
-
   test "iodata", context do
     assert [{123}] = query(["S", ?E, ["LEC"|"T"], " ", '123'], [])
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -419,14 +419,28 @@ defmodule QueryTest do
     assert res.num_rows == 1
   end
 
-  test "error record", context do
+  test "error struct", context do
     assert {:error, %Postgrex.Error{}} = P.query(context[:pid], "SELECT 123 + 'a'", [])
   end
 
-  test "multi row result", context do
+  test "multi row result struct", context do
     assert {:ok, res} = P.query(context[:pid], "VALUES (1, 2), (3, 4)", [])
     assert res.num_rows == 2
     assert res.rows == [[1, 2], [3, 4]]
+  end
+
+  test "multi row result struct with manual decoding", context do
+    assert {:ok, res} = P.query(context[:pid], "VALUES (1, 2), (3, 4)", [], decode: :manual)
+    assert res.rows == [[<<0, 0, 0, 3>>, <<0, 0, 0, 4>>],
+                        [<<0, 0, 0, 1>>, <<0, 0, 0, 2>>]]
+
+    assert P.decode(res).rows == [[1, 2], [3, 4]]
+
+    res = P.decode(res, &Enum.map(&1, fn x -> x * 2 end))
+    assert res.rows == [[2, 4], [6, 8]]
+
+    res = P.decode(res, & &1 * 2)
+    assert res.rows == [[2, 4], [6, 8]]
   end
 
   test "insert", context do

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -12,17 +12,16 @@ defmodule SchemaTest do
 
   @tag min_pg_version: "9.1"
   test "encode hstore", context do
-    assert [{%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}}] =
+    assert [[%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}]] =
            query ~s(SELECT $1::test.hstore), [%{"name" => "Frank", "bubbles" => "7", "limit" => nil, "chillin"=> "true", "fratty"=> "false", "atom" => "bomb"}]
   end
 
   @tag min_pg_version: "9.1"
   test "decode hstore inside a schema", context do
-    assert [{%{}}] = query(~s{SELECT ''::test.hstore}, [])
-    assert [{%{"Bubbles" => "7", "Name" => "Frank"}}] = query(~s{SELECT '"Name" => "Frank", "Bubbles" => "7"'::test.hstore}, [])
-    assert [{%{"non_existant" => nil, "present" => "&accounted_for"}}] = query(~s{SELECT '"non_existant" => NULL, "present" => "&accounted_for"'::test.hstore}, [])
-    assert [{%{"spaces in the key" => "are easy!", "floats too" => "66.6"}}] = query(~s{SELECT '"spaces in the key" => "are easy!", "floats too" => "66.6"'::test.hstore}, [])
-    assert [{%{"this is true" => "true", "though not this" => "false"}}] = query(~s{SELECT '"this is true" => "true", "though not this" => "false"'::test.hstore}, [])
+    assert [[%{}]] = query(~s{SELECT ''::test.hstore}, [])
+    assert [[%{"Bubbles" => "7", "Name" => "Frank"}]] = query(~s{SELECT '"Name" => "Frank", "Bubbles" => "7"'::test.hstore}, [])
+    assert [[%{"non_existant" => nil, "present" => "&accounted_for"}]] = query(~s{SELECT '"non_existant" => NULL, "present" => "&accounted_for"'::test.hstore}, [])
+    assert [[%{"spaces in the key" => "are easy!", "floats too" => "66.6"}]] = query(~s{SELECT '"spaces in the key" => "are easy!", "floats too" => "66.6"'::test.hstore}, [])
+    assert [[%{"this is true" => "true", "though not this" => "false"}]] = query(~s{SELECT '"this is true" => "true", "though not this" => "false"'::test.hstore}, [])
   end
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -91,7 +91,7 @@ Enum.each(cmds, fn cmd ->
     Please verify the user "postgres" exists and it has permissions to
     create databases and users. If not, you can create a new user with:
 
-    $ createuser postgres -d -r --no-password
+    $ createuser postgres -s --no-password
     """
     System.halt(1)
   end

--- a/test/type_server_test.exs
+++ b/test/type_server_test.exs
@@ -1,0 +1,121 @@
+defmodule TypeServerTest do
+  use ExUnit.Case, async: true
+  alias Postgrex.TypeServer, as: TS
+
+  test "does not unlock unknown references" do
+    assert TS.unlock(make_ref) == :error
+  end
+
+  test "fetches and unlocks" do
+    key = make_ref()
+    assert {:lock, ref, table} = TS.fetch(key)
+    assert :ets.info(table, :name) == :postgrex_type_server
+    assert TS.unlock(ref) == :ok
+  end
+
+  test "blocks on fetch until lock is returned" do
+    key = make_ref()
+    {:lock, ref, table} = TS.fetch(key)
+
+    task = Task.async fn -> TS.fetch(key) end
+    TS.unlock(ref)
+    assert Task.await(task) == {:ok, table}
+  end
+
+  test "fetches existing table" do
+    key = make_ref()
+    {:lock, ref, table} = TS.fetch(key)
+    TS.unlock(ref)
+
+    task = Task.async(fn -> TS.fetch(key) end)
+    assert Task.await(task) == {:ok, table}
+  end
+
+  test "fetches existing table even if parent crashes" do
+    key = make_ref()
+
+    task = Task.async fn ->
+      {:lock, ref, table} = TS.fetch(key)
+      TS.unlock(ref)
+      table
+    end
+    table = Task.await(task)
+    wait_until_dead(task.pid)
+
+    task = Task.async(fn -> TS.fetch(key) end)
+    assert Task.await(task) == {:ok, table}
+  end
+
+  test "fetches existing table even if other processes crashes" do
+    key = make_ref()
+
+    {:lock, ref, table} = TS.fetch(key)
+    TS.unlock(ref)
+
+    assert Task.async(fn -> TS.fetch(key) end) |> Task.await() == {:ok, table}
+    assert Task.async(fn -> TS.fetch(key) end) |> Task.await() == {:ok, table}
+    assert Task.async(fn -> TS.fetch(key) end) |> Task.await() == {:ok, table}
+  end
+
+  test "does not fetch existing table if parent crashes and timeout passes" do
+    Application.put_env(:postgrex, :type_server_reap_after, 0)
+    key = make_ref()
+
+    # Setup trace
+    ts = Process.whereis(TS)
+    :erlang.trace(ts, true, [:receive])
+
+    task = Task.async fn ->
+      {:lock, ref, table} = TS.fetch(key)
+      TS.unlock(ref)
+      table
+    end
+    table1 = Task.await(task)
+    wait_until_dead(task.pid)
+
+    # Wait until timeout kicks in
+    assert_receive {:trace, ^ts, :receive, {:drop, _, _}}
+
+    task = Task.async(fn -> TS.fetch(key) end)
+    assert {:lock, _, table2} = Task.await(task)
+
+    assert table1 != table2
+    assert :ets.info(table1, :name) == :undefined
+  after
+    Application.put_env(:postgrex, :type_server_reap_after, 3 * 60_000)
+  end
+
+  test "gives lock to another process if original holder crashes before fetch" do
+    key = make_ref()
+
+    task = Task.async(fn -> TS.fetch(key) end)
+    assert {:lock, _ref, table1} = Task.await(task)
+    wait_until_dead(task.pid)
+
+    assert {:lock, _ref, table2} =
+           Task.async(fn -> TS.fetch(key) end) |> Task.await
+    assert table1 != table2
+  end
+
+  test "gives lock to another process if original holder crashes after fetch" do
+    key = make_ref()
+    top = self()
+
+    {:ok, pid} = Task.start fn ->
+      send(top, TS.fetch(key))
+      :timer.sleep(:infinity)
+    end
+
+    assert_receive {:lock, _, _}
+    task = Task.async(fn -> TS.fetch(key) end)
+
+    Process.exit(pid, :kill)
+    wait_until_dead(pid)
+    assert {:lock, _, _} = Task.await(task)
+  end
+
+  defp wait_until_dead(pid) do
+    ref = Process.monitor(pid)
+    receive do: ({:DOWN, ^ref, _, _, _} -> :ok)
+  end
+end


### PR DESCRIPTION
This pull request:

1. caches types on ETS to save memory
2. move processing to clients
3. allow clients to decode manually, with an optional mapper function to avoid traversing the collection multiple times