### PR TITLE
Send parse/describe/flush not parse/describe/sync.

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -454,8 +454,14 @@ defmodule QueryTest do
     assert %Postgrex.Error{postgres: %{code: :syntax_error}} = query("wat", [])
   end
 
-  test "connection works after failure", context do
+  test "connection works after failure in parsing state", context do
     assert %Postgrex.Error{} = query("wat", [])
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "connection works after failure in executing state", context do
+    assert %Postgrex.Error{postgres: %{code: :unique_violation}} =
+      query("insert into uniques values (1), (1);", [])
     assert [[42]] = query("SELECT 42", [])
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -45,6 +45,8 @@ CREATE TABLE composite2 (a int, b int, c int);
 
 DROP TYPE IF EXISTS enum1;
 CREATE TYPE enum1 AS ENUM ('elixir', 'erlang');
+
+CREATE TABLE uniques (a int UNIQUE);
 """
 
 sql_with_schemas = """


### PR DESCRIPTION
> RhodiumToad: that first sync shouldn't be there
> RhodiumToad: if you need the result of the describe before doing the bind, then use flush, not sync

This changes Postgrex to not send parse/describe/sync but parse/describe/flush.