### PR TITLE
Updating README - Changing to v0.9.1 version in the usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add Postgrex as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:postgrex, "~> 0.8"} ]
+  [{:postgrex, "~> 0.9.1"} ]
 end
 ```
 


### PR DESCRIPTION
Just a little update in the "Usage" section in the README.