### PR TITLE
Change `len` to uint16 for parsing parameter_desc

### DIFF
--- a/lib/postgrex/messages.ex
+++ b/lib/postgrex/messages.ex
@@ -80,19 +80,19 @@ defmodule Postgrex.Messages do
   end
 
   # parameter_desc
-  def parse(<<len :: int16, rest :: binary(len, 32)>>, ?t, _size) do
+  def parse(<<len :: uint16, rest :: binary(len, 32)>>, ?t, _size) do
     oids = for <<oid :: size(32) <- rest>>, do: oid
     msg_parameter_desc(type_oids: oids)
   end
 
   # row_desc
-  def parse(<<len :: int16, rest :: binary>>, ?T, _size) do
+  def parse(<<len :: uint16, rest :: binary>>, ?T, _size) do
     fields = decode_row_fields(rest, len)
     msg_row_desc(fields: fields)
   end
 
   # data_row
-  def parse(<<count :: int16, rest :: binary>>, ?D, _size) do
+  def parse(<<count :: uint16, rest :: binary>>, ?D, _size) do
     values = decode_row_values(rest, count)
     msg_data_row(values: values)
   end
@@ -285,7 +285,7 @@ defmodule Postgrex.Messages do
     [nil | decode_row_values(rest, count-1)]
   end
 
-  defp decode_row_values(<<length :: int32, value :: binary(length), rest :: binary>>, count) do
+  defp decode_row_values(<<length :: uint32, value :: binary(length), rest :: binary>>, count) do
     [value | decode_row_values(rest, count-1)]
   end
 


### PR DESCRIPTION
This addresses #96. While Postgres's documentation on its use of signed vs unsigned integers is nearly non-existent, digging into [its source code](http://doxygen.postgresql.org/fe-misc_8c_source.html#l00272) shows that a uint16 is being used to store the number of parameters (Postgres's `getParamDescriptions` method calls into `pgGetInt` with a size of 2, which uses `uint16`).

I also [found discussions](http://www.postgresql.org/message-id/20120901160523.GD2969@momjian.us) that sometimes they use signed integers and sometimes unsigned.

Because of this uncertainty, I'm uncomfortable changing other clauses of `parse` to use unsigned integers without double checking each one.

I would LOVE to have a test for this change, but I have no clue where to even start on testing this (and it looks like there aren't any specific unit tests on the Messages module?) The only thing I can think is adding a query test with more than 32,767 parameters and ensuring it works? Let me know your thoughts and I can get something added. Thanks!