### PR TITLE
Unknown error codes should return rather than fail to match

### DIFF
--- a/lib/postgrex/error_code.ex
+++ b/lib/postgrex/error_code.ex
@@ -36,6 +36,7 @@ defmodule Postgrex.ErrorCode do
     [{^code, name}] = errcodes
     def code_to_name(unquote(code)), do: unquote(name)
   end
+  def code_to_name(code), do: code
 
   @doc ~S"""
   Translates a Postgres error name into a list of possible codes.

--- a/lib/postgrex/error_code.ex
+++ b/lib/postgrex/error_code.ex
@@ -36,7 +36,7 @@ defmodule Postgrex.ErrorCode do
     [{^code, name}] = errcodes
     def code_to_name(unquote(code)), do: unquote(name)
   end
-  def code_to_name(code), do: code
+  def code_to_name(_), do: nil
 
   @doc ~S"""
   Translates a Postgres error name into a list of possible codes.

--- a/test/error_code_test.exs
+++ b/test/error_code_test.exs
@@ -8,7 +8,7 @@ defmodule ErrorCodeTest do
     assert code_to_name("23505") == :unique_violation
     assert code_to_name("2F003") == :prohibited_sql_statement_attempted
     assert code_to_name("38003") == :prohibited_sql_statement_attempted
-    assert catch_error(code_to_name("nope"))
+    assert code_to_name("nope") == nil
   end
 
   test "name to codes" do


### PR DESCRIPTION
I'm using postgrex with some plpgsql functions that raise a custom error. The code to string conversion should fall through to return the code if the code is not in the list of errors.