### PR TITLE
Allow decoding result without blocking connection

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -92,7 +92,7 @@ defmodule Postgrex.Connection do
     try do
       Connection.call(pid, {:query, ref, timeout}, queue_timeout)
     catch
-      :exit, {_, {Connection, :call, [pid | _]}} = reason ->
+      :exit, {_, {_, :call, [pid | _]}} = reason ->
         Connection.cast(pid, {:cancel, ref})
         exit(reason)
     else
@@ -301,7 +301,7 @@ defmodule Postgrex.Connection do
   end
 
   def handle_info({:timeout, timer, __MODULE__}, %{timer: timer} = s) when is_reference(timer) do
-    {:stop, :query_timeout, s}
+    {:stop, {:shutdown, :timeout}, s}
   end
 
   def handle_info(msg, s) do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -1,179 +1,90 @@
 defmodule Postgrex.Protocol do
   @moduledoc false
 
-  alias Postgrex.Connection
   alias Postgrex.Types
   import Postgrex.Messages
-  import Postgrex.Utils
   import Postgrex.BinaryUtils
   require Logger
 
   @timeout 5000
   @default_extensions [{Postgrex.Extensions.Binary, nil}, {Postgrex.Extensions.Text, nil}]
-  @sock_opts [active: false, mode: :binary]
+  @sock_opts [packet: :raw, mode: :binary, active: false]
 
+  ## TODO: Use struct for state
+  @type state :: %{}
+  @typep parameters :: %{binary => binary}
+  @typep notifications :: [{binary, binary}]
+
+  @spec init(Keyword.t) ::
+    {:ok, state, parameters, notifications} | {:stop, %Postgrex.Error{}}
   def init(opts) do
     host       = Keyword.fetch!(opts, :hostname) |> to_char_list
     port       = opts[:port] || 5432
     timeout    = opts[:timeout] || @timeout
-    sock_opts  = [{:packet, :raw}, :binary] ++ (opts[:socket_options] || [])
+    sock_opts  = [send_timeout: timeout] ++ (opts[:socket_options] || [])
     custom     = opts[:extensions] || []
     extensions = custom ++ @default_extensions
-    ssl?       = opts[:ssl] || false
+
+    s = %{sock: nil, backend_key: nil, types: nil, timeout: timeout}
 
     types_key = {host, port, Keyword.fetch!(opts, :database), custom}
-    s = %{sock: nil, tail: "", state: :init, parameters: %{}, backend_key: nil,
-          rows: [], statement: nil, portal: nil, types: nil,
-          queue: :queue.new, timeout: timeout, extensions: extensions,
-          listeners: HashDict.new, listener_channels: HashDict.new,
-          types_key: types_key}
-    case connect(host, port, sock_opts, s) do
-      {:ok, s} when ssl? -> ssl(s, opts)
-      {:ok, s}           -> startup(s, opts)
-      {:stop, _} = stop  -> stop
+    status = %{opts: opts, parameters: %{}, notifications: [],
+               types_key: types_key, types_ref: nil, extensions: extensions,
+               extension_info: nil}
+    case connect(host, port, sock_opts ++ @sock_opts, s) do
+      {:ok, s}           -> init(s, status)
+      {:stop, reason, _} -> {:stop, reason}
     end
   end
 
-  def send_query(statement, s) do
-    msgs = [
-      msg_parse(name: "", query: statement, type_oids: []),
-      msg_describe(type: :statement, name: ""),
-      msg_flush() ]
-
-    case send_to_result(msgs, s) do
-      {:ok, s} ->
-        {:ok, %{s | statement: nil, state: :parsing}}
-      err ->
-        err
+  @spec handle_query(String.t, [any], state) ::
+    {:ok, %Postgrex.Result{}, state, parameters, notifications} |
+    {:stop, %Postgrex.Error{}, state}
+  def handle_query(statement, params, s) do
+    status = %{parameters: %{}, notifications: [], portal: nil,
+               column_oids: nil, columns: nil}
+    case describe(s, status, statement, :active_once) do
+      {:ok, %Postgrex.Error{}, _, _, _} = ok ->
+        ok
+      {:ok, rfs, s, status, buffer} ->
+        execute(s, status, params, rfs, buffer)
+      {:stop, _, _} = stop ->
+        stop
     end
   end
 
-  # possible states: init, parsing, describing, binding, executing, ready
-
-  ### parsing state ###
-
-  def message(:parsing, msg_parse_complete(), s) do
-    {:ok, %{s | state: :describing}}
+  @spec handle_info(any, state) ::
+    {:ok, state, parameters, notifications} | {:stop, %Postgrex.Error{}, state}
+  def handle_info({:tcp, sock, data}, %{sock: {:gen_tcp, sock}} = s) do
+    data(s, data)
   end
-
-  ### describing state ###
-
-  def message(:describing, msg_no_data(), s) do
-    send_params(s, [])
+  def handle_info({:tcp_closed, sock}, %{sock: {:gen_tcp, sock}} = s) do
+    error(Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: :closed), s)
   end
-
-  def message(:describing, msg_parameter_desc(type_oids: oids), s) do
-    {:ok, %{s | portal: oids}}
+  def handle_info({:tcp_error, sock, reason}, %{sock: {:gen_tcp, sock}} = s) do
+    error(Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: reason), s)
   end
-
-  def message(:describing, msg_row_desc(fields: fields), s) do
-    {col_oids, col_names} = columns(fields)
-    try do
-      result_formats = result_formats(col_oids, s.types)
-      stat = %{columns: col_names, column_oids: col_oids}
-      send_params(%{s | statement: stat}, result_formats)
-    catch
-      kind, reason ->
-        reply(exit_reply(kind, reason, System.stacktrace), s)
-        send_to_result([msg_sync], s)
-    end
+  def handle_info({:ssl, sock, data}, %{sock: {:ssl, sock}} = s) do
+    data(s, data)
   end
-
-  ### binding state ###
-
-  def message(:binding, msg_bind_complete(), s) do
-    {:ok, %{s | state: :executing}}
+  def handle_info({:ssl_closed, sock}, %{sock: {:ssl, sock}} = s) do
+    error(Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: :closed), s)
   end
-
-  ### executing state ###
-
-  def message(:executing, msg_data_row(values: values), s) do
-    {:ok, %{s | rows: [values|s.rows]}}
+  def handle_info({:ssl_error, sock, reason}, %{sock: {:ssl, sock}} = s) do
+    error(Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: reason), s)
   end
-
-  def message(:executing, msg_command_complete(tag: tag), s) do
-    {command, nrows} = decode_tag(tag)
-
-    reply =
-      if is_nil(s.statement) do
-        result = %Postgrex.Result{command: command, num_rows: nrows || 0}
-        {:ok, result}
-      else
-        %{statement: %{column_oids: col_oids, columns: cols},
-          types: types, rows: rows} = s
-
-        # Fix for PostgreSQL 8.4 (doesn't include number of selected rows in tag)
-        if is_nil(nrows) and command == :select do
-          nrows = length(rows)
-        end
-
-        try do
-          decode_rows(rows, col_oids, types)
-        catch
-          kind, reason ->
-            exit_reply(kind, reason, System.stacktrace)
-        else
-          decoded ->
-            result = %Postgrex.Result{command: command, num_rows: nrows || 0,
-                                      rows: decoded, columns: cols}
-            {:ok, result}
-        end
-      end
-
-    reply(reply, s)
-    {:ok, %{s | rows: [], statement: nil, portal: nil}}
-  end
-
-  def message(:executing, msg_empty_query(), s) do
-    reply({:ok, %Postgrex.Result{}}, s)
-    {:ok, s}
-  end
-
-  ### asynchronous messages ###
-
-  def message(_, msg_ready(), s) do
-    queue = :queue.drop(s.queue)
-    Connection.next(%{s | queue: queue, state: :ready})
-  end
-
-  def message(_, msg_parameter(name: name, value: value), s) do
-    params = Map.put(s.parameters, name, value)
-    {:ok, %{s | parameters: params}}
-  end
-
-  def message(state, msg_error(fields: fields), s) do
-    error = {:error, Postgrex.Error.exception(postgres: fields)}
-    unless reply(error, s) do
-      Logger.warn(fn ->
-        ["Unhandled Postgres error: ", Postgrex.Error.message(error)]
-      end)
-    end
-    if state in [:parsing, :describing] do
-      # Issue a Sync to get back into valid state when error happened before bind/execute/sync.
-      send_to_result([msg_sync], s)
-    else
-      {:ok, s}
-    end
-  end
-
-  def message(_, msg_notice(), s) do
-    # TODO: subscribers
-    {:ok, s}
-  end
-
-  def message(_, msg_notify(channel: channel, payload: payload), s) do
-    refs = HashDict.get(s.listener_channels, channel) || []
-    Enum.each(refs, fn ref ->
-      {_channel, pid} = s.listeners[ref]
-      send(pid, {:notification, self(), ref, channel, payload})
-    end)
-    {:ok, s}
+  def handle_info(_, s) do
+    # TODO: log unknown messages
+    {:ok, s, %{}, []}
   end
 
   ## connect
 
   defp connect(host, port, sock_opts, %{timeout: timeout} = s) do
+    buffer? = Keyword.has_key?(sock_opts, :buffer)
     case :gen_tcp.connect(host, port, sock_opts ++ @sock_opts, timeout) do
+      {:ok, sock} when buffer? ->
+        {:ok, %{s | sock: {:gen_tcp, sock}}}
       {:ok, sock} ->
         # A suitable :buffer is only set if :recbuf is included in
         # :socket_options.
@@ -184,25 +95,37 @@ defmodule Postgrex.Protocol do
           |> max(recbuf)
         :ok = :inet.setopts(sock, [buffer: buffer])
         {:ok, %{s | sock: {:gen_tcp, sock}}}
-
       {:error, reason} ->
         error(Postgrex.Error.exception(tag: :tcp, action: "connect", reason: reason),s)
     end
   end
 
+  ## init
+
+  defp init(s, %{opts: opts} = status) do
+    next = case opts[:ssl] || false do
+      true -> &ssl/2
+      false -> &startup/2
+    end
+    case next.(s, status) do
+      {:ok, _, _, _} = ok -> ok
+      {:stop, reason, _}  -> {:stop, reason}
+    end
+  end
+
   ## ssl
 
-  defp ssl(%{sock: sock} = s, opts) do
+  defp ssl(%{sock: sock} = s, status) do
     case msg_send(msg_ssl_request(), sock) do
-      :ok              -> ssl_recv(s, opts)
+      :ok              -> ssl_recv(s, status)
       {:error, exception} -> error(exception, s)
     end
   end
 
-  defp ssl_recv(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, opts) do
+  defp ssl_recv(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, status) do
     case :gen_tcp.recv(sock, 1, timeout) do
       {:ok, <<?S>>} ->
-        ssl_connect(s, opts)
+        ssl_connect(s, status)
       {:ok, <<?N>>} ->
         error(%Postgrex.Error{message: "ssl not available"}, s)
       {:error, reason} ->
@@ -210,10 +133,10 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp ssl_connect(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, opts) do
-    case :ssl.connect(sock, opts[:ssl_opts] || [], timeout) do
+  defp ssl_connect(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, status) do
+    case :ssl.connect(sock, status.opts[:ssl_opts] || [], timeout) do
       {:ok, ssl_sock} ->
-        startup(%{s | sock: {:ssl, ssl_sock}}, opts)
+        startup(%{s | sock: {:ssl, ssl_sock}}, status)
       {:error, reason} ->
         error(Postgrex.Error.exception(tag: :ssl, action: "connect", reason: reason),s)
     end
@@ -221,14 +144,14 @@ defmodule Postgrex.Protocol do
 
   ## startup
 
-  defp startup(%{sock: sock} = s, opts) do
+  defp startup(%{sock: sock} = s, %{opts: opts} = status) do
     params = opts[:parameters] || []
     user = Keyword.fetch!(opts, :username)
     database = Keyword.fetch!(opts, :database)
     msg = msg_startup(params: [user: user, database: database] ++ params)
     case msg_send(msg, sock) do
       :ok ->
-        auth_recv(s, opts, <<>>)
+        auth_recv(s, status, <<>>)
       {:error, exception} ->
         error(exception, s)
     end
@@ -236,14 +159,14 @@ defmodule Postgrex.Protocol do
 
   ## auth
 
-  defp auth_recv(%{sock: sock, timeout: timeout} = s, opts, buffer) do
+  defp auth_recv(%{sock: sock, timeout: timeout} = s, status, buffer) do
     case msg_recv(sock, buffer, timeout) do
       {:ok, msg_auth(type: :ok), buffer} ->
-        init_recv(s, buffer)
+        init_recv(s, status, buffer)
       {:ok, msg_auth(type: :cleartext), buffer} ->
-        auth_cleartext(s, opts, buffer)
+        auth_cleartext(s, status, buffer)
       {:ok, msg_auth(type: :md5, data: salt), buffer} ->
-        auth_md5(s, opts, salt, buffer)
+        auth_md5(s, status, salt, buffer)
       {:ok, msg_error(fields: fields), _} ->
         error(Postgrex.Error.exception(postgres: fields), s)
       {:error, exception} ->
@@ -251,12 +174,12 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp auth_cleartext(s, opts, buffer) do
+  defp auth_cleartext(s, %{opts: opts} = status, buffer) do
     pass = Keyword.fetch!(opts, :password)
-    auth_send(s, msg_password(pass: pass), opts, buffer)
+    auth_send(s, msg_password(pass: pass), status, buffer)
   end
 
-  defp auth_md5(s, opts, salt, buffer) do
+  defp auth_md5(s, %{opts: opts} = status, salt, buffer) do
     user = Keyword.fetch!(opts, :username)
     pass = Keyword.fetch!(opts, :password)
 
@@ -264,13 +187,13 @@ defmodule Postgrex.Protocol do
     |> Base.encode16(case: :lower)
     digest = :crypto.hash(:md5, [digest, salt])
     |> Base.encode16(case: :lower)
-    auth_send(s, msg_password(pass: ["md5", digest]), opts, buffer)
+    auth_send(s, msg_password(pass: ["md5", digest]), status, buffer)
   end
 
-  defp auth_send(%{sock: sock} = s, msg, opts, buffer) do
+  defp auth_send(%{sock: sock} = s, msg, status, buffer) do
     case msg_send(msg, sock) do
       :ok ->
-        auth_recv(s, opts, buffer)
+        auth_recv(s, status, buffer)
       {:error, exception} ->
         error(exception, s)
     end
@@ -278,17 +201,16 @@ defmodule Postgrex.Protocol do
 
   ## init
 
-  defp init_recv(%{sock: sock, timeout: timeout} = s, buffer) do
+  defp init_recv(%{sock: sock, timeout: timeout} = s, status, buffer) do
     case msg_recv(sock, buffer, timeout) do
       {:ok, msg_backend_key(pid: pid, key: key), buffer} ->
-        init_recv(%{s | backend_key: {pid, key}}, buffer)
+        init_recv(%{s | backend_key: {pid, key}}, status, buffer)
       {:ok, msg_ready(), buffer} ->
-        bootstrap(s, buffer)
+        bootstrap(s, status, buffer)
       {:ok, msg_error(fields: fields), _} ->
         error(Postgrex.Error.exception(postgres: fields), s)
       {:ok, msg, buffer} ->
-        {:ok, s} = message(:init, msg, s)
-        init_recv(s, buffer)
+        init_recv(s, handle_msg(status, msg), buffer)
       {:error, exception} ->
         error(exception, s)
     end
@@ -296,22 +218,19 @@ defmodule Postgrex.Protocol do
 
   ## bootstrap
 
-  defp bootstrap(%{types_key: types_key} = s, buffer) do
+  defp bootstrap(s, %{types_key: types_key} = status, buffer) do
     case Postgrex.TypeServer.fetch(types_key) do
       {:ok, table} ->
-        bootstrap_ready(%{s | types: table}, buffer)
+        ok(%{s | types: table}, status, buffer)
       {:lock, ref, table} ->
-        bootstrap_send(%{s | types: table}, ref, buffer)
+        status = %{status | types_ref: ref}
+        bootstrap_send(%{s | types: table}, status, buffer)
     end
   end
 
-  defp bootstrap_ready(%{sock: {mod, sock}} = s, buffer) do
-    send(self(), {tag(mod), sock, buffer})
-    {:ok, %{s | state: :ready}}
-  end
+  defp bootstrap_send(%{sock: sock} = s, status, buffer) do
+    %{parameters: parameters, extensions: extensions} = status
 
-  defp bootstrap_send(s, ref, buffer) do
-    %{parameters: parameters, extensions: extensions, sock: sock} = s
     extension_keys = Enum.map(extensions, &elem(&1, 0))
     extension_opts = Types.prepare_extensions(extensions, parameters)
     matchers = Types.extension_matchers(extension_keys, extension_opts)
@@ -320,67 +239,232 @@ defmodule Postgrex.Protocol do
     msg = msg_query(query: query)
     case msg_send(msg, sock) do
       :ok ->
-        bootstrap_recv(s, ref, {extension_keys, extension_opts}, buffer)
+        status = %{status | extension_info: {extension_keys, extension_opts}}
+        bootstrap_recv(s, status, buffer)
       {:error, exception} ->
         error(exception, s)
     end
   end
 
-  defp bootstrap_recv(s, ref, extension_info, buffer) do
+  defp bootstrap_recv(s, status, buffer) do
     %{sock: sock, timeout: timeout} = s
     case msg_recv(sock, buffer, timeout) do
       {:ok, msg_row_desc(), buffer} ->
-        bootstrap_recv(s, ref, extension_info, [], buffer)
+        bootstrap_recv(s, status, [], buffer)
       {:ok, msg_error(fields: fields), _} ->
         error(Postgrex.Error.exception(postgres: fields), s)
       {:ok, msg, buffer} ->
-        {:ok, s} = message(:init, msg, s)
-        bootstrap_recv(s, ref, extension_info, buffer)
+        bootstrap_recv(s, handle_msg(status, msg), buffer)
       {:error, exception} ->
         error(exception, s)
     end
   end
 
-  defp bootstrap_recv(s, ref, extension_info, rows, buffer) do
+  defp bootstrap_recv(s, status, rows, buffer) do
     %{sock: sock, timeout: timeout} = s
     case msg_recv(sock, buffer, timeout) do
       {:ok, msg_data_row(values: values), buffer} ->
-        bootstrap_recv(s, ref, extension_info, [values | rows], buffer)
+        bootstrap_recv(s, status, [values | rows], buffer)
       {:ok, msg_command_complete(), buffer} ->
-        bootstrap_types(s, ref, extension_info, rows, buffer)
+        bootstrap_types(s, status, rows, buffer)
       {:ok, msg_error(fields: fields), _} ->
         error(Postgrex.Error.exception(postgres: fields), s)
       {:ok, msg, buffer} ->
-        {:ok, s} = message(:init, msg, s)
-        bootstrap_recv(s, ref, extension_info, rows, buffer)
+        bootstrap_recv(s, handle_msg(status, msg), rows, buffer)
       {:error, exception} ->
         error(exception, s)
     end
   end
 
-  defp bootstrap_types(s, ref, {extension_keys, extension_opts}, rows, buffer) do
-    %{types: table} = s
+  defp bootstrap_types(%{types: table} = s, status, rows, buffer) do
+    %{types_ref: ref, extension_info: {extension_keys, extension_opts}} = status
     types = Types.build_types(rows)
     Types.associate_extensions_with_types(table, extension_keys, extension_opts, types)
     Postgrex.TypeServer.unlock(ref)
-    bootstrap_await(s, buffer)
+    bootstrap_await(s, status, buffer)
   end
 
-  defp bootstrap_await(%{sock: sock, timeout: timeout} = s, buffer) do
+  defp bootstrap_await(%{sock: sock, timeout: timeout} = s, status, buffer) do
     case msg_recv(sock, buffer, timeout) do
       {:ok, msg_ready(), buffer} ->
-        bootstrap_ready(s, buffer)
+        ok(s, status, buffer)
       {:ok, msg_error(fields: fields), _} ->
         error(Postgrex.Error.exception(postgres: fields), s)
       {:ok, msg, buffer} ->
-        {:ok, s} = message(:init, msg, s)
-        bootstrap_await(s, buffer)
+        bootstrap_await(s, handle_msg(status, msg), buffer)
       {:error, exception}  ->
         error(exception, s)
     end
   end
 
-  ### helpers ###
+  ## describe
+
+  defp describe(s, status, statement, buffer) do
+    msgs = [
+      msg_parse(name: "", query: statement, type_oids: []),
+      msg_describe(type: :statement, name: ""),
+      msg_flush() ]
+    case msg_send(msgs, s) do
+      :ok ->
+        parse_recv(s, status, buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp parse_recv(s, status, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_parse_complete(), buffer} ->
+        describe_recv(s, status, buffer)
+      {:ok, msg_error(fields: fields), buffer} ->
+        error(Postgrex.Error.exception(postgres: fields), s, status, buffer)
+      {:ok, msg, buffer} ->
+        parse_recv(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp describe_recv(s, status, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_no_data(), buffer} ->
+        {:ok, [], s, status, buffer}
+      {:ok, msg_parameter_desc(type_oids: param_oids), buffer} ->
+        describe_recv(s, %{status | portal: param_oids}, buffer)
+      {:ok, msg_row_desc(fields: fields), buffer} ->
+        {col_oids, col_names} = columns(fields)
+        ## TODO: Handle result_formats/2 exceptions.
+        result_formats = result_formats(col_oids, s.types)
+        status = %{status | columns: col_names, column_oids: col_oids}
+        {:ok, result_formats, s, status, buffer}
+      {:ok, msg_error(fields: fields), buffer} ->
+        error(Postgrex.Error.exception(postgres: fields), s, status, buffer)
+      {:ok, msg, buffer} ->
+        describe_recv(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  ## execute
+
+  defp execute(s, status, params, rfs, buffer) do
+    try do
+      encode_params(s, status, params)
+    catch
+      kind, reason ->
+        sync_exit(kind, reason, System.stacktrace, s, status, buffer)
+    else
+      {pfs, params} ->
+        execute(s, status, pfs, params, rfs, buffer)
+    end
+  end
+
+  defp execute(s, status, pfs, params, rfs, buffer) do
+    msgs = [
+      msg_bind(name_port: "", name_stat: "", param_formats: pfs, params: params, result_formats: rfs),
+      msg_execute(name_port: "", max_rows: 0),
+      msg_sync() ]
+    case msg_send(msgs, s) do
+      :ok ->
+        bind_recv(s, status, buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp bind_recv(s, status, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_bind_complete(), buffer} ->
+        execute_recv(s, status, buffer)
+      {:ok, msg_error(fields: fields), _} ->
+        error(Postgrex.Error.exception(postgres: fields), s)
+      {:ok, msg, buffer} ->
+        bind_recv(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp execute_recv(s, status, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_data_row(values: values), buffer} ->
+        execute_recv(s, status, [values], buffer)
+      {:ok, msg_command_complete(tag: tag), buffer} ->
+        complete(s, status, [], tag, buffer)
+      {:ok, msg_empty_query(), buffer} ->
+        ok(%Postgrex.Result{}, s, status, buffer)
+      {:ok, msg_error(fields: fields), buffer} ->
+        error(Postgrex.Error.exception(postgres: fields), s, status, buffer)
+      {:ok, msg, buffer} ->
+        execute_recv(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp execute_recv(s, status, rows, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_data_row(values: values), buffer} ->
+        execute_recv(s, status, [values | rows], buffer)
+      {:ok, msg_command_complete(tag: tag), buffer} ->
+        complete(s, status, rows, tag, buffer)
+      {:ok, msg_error(fields: fields), _} ->
+        error(Postgrex.Error.exception(postgres: fields), s)
+      {:ok, msg, buffer} ->
+        execute_recv(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp complete(s, %{columns: nil} = status, [], tag, buffer) do
+    {command, nrows} = decode_tag(tag)
+    result =  %Postgrex.Result{command: command, num_rows: nrows || 0}
+    ok(result, s, status, buffer)
+  end
+  defp complete(%{types: types} = s, status, rows, tag, buffer) do
+    {command, nrows} = decode_tag(tag)
+    %{column_oids: col_oids, columns: cols} = status
+    # Fix for PostgreSQL 8.4 (doesn't include number of selected rows in tag)
+    if is_nil(nrows) and command == :select do
+      nrows = length(rows)
+    end
+    try do
+      decode_rows(rows, col_oids, types)
+    catch
+      kind, reason ->
+        exit(kind, reason, System.stacktrace, s, status, buffer)
+    else
+      decoded ->
+        result = %Postgrex.Result{command: command, num_rows: nrows || 0,
+          rows: decoded, columns: cols}
+        ok(result, s, status, buffer)
+    end
+  end
+
+  ## data
+
+  defp data(s, status \\ %{parameters: %{}, notifications: []}, buffer) do
+    %{sock: sock, timeout: timeout} = s
+    case msg_recv(sock, buffer, timeout) do
+      {:ok, msg_error(fields: fields), _} ->
+        error(Postgrex.Error.exception(postgres: fields), s)
+      {:ok, msg, <<>>} ->
+        ok(s, handle_msg(status, msg), <<>>)
+      {:ok, msg, buffer} ->
+        data(s, handle_msg(status, msg), buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  ## helpers
 
   defp decode_rows(rows, col_oids, types) do
     decoders = for oid <- col_oids, do: Postgrex.Types.decoder(oid, types)
@@ -400,33 +484,7 @@ defmodule Postgrex.Protocol do
   end
   defp decode_row([], []), do: []
 
-  defp send_params(s, rfs) do
-    {msgs, s} =
-      try do
-        encode_params(s)
-      catch
-        kind, reason ->
-          reply(exit_reply(kind, reason, System.stacktrace), s)
-          {[msg_sync], %{s | portal: nil}}
-      else
-        {pfs, params} ->
-          msgs = [
-            msg_bind(name_port: "", name_stat: "", param_formats: pfs, params: params, result_formats: rfs),
-            msg_execute(name_port: "", max_rows: 0),
-            msg_sync() ]
-          {msgs, %{s | state: :binding}}
-      end
-
-    case send_to_result(msgs, s) do
-      {:ok, s} ->
-        {:ok, s}
-      err ->
-        err
-    end
-  end
-
-  defp encode_params(%{queue: queue, portal: param_oids, types: types}) do
-    %{command: {:query, _statement, params}} = :queue.get(queue)
+  defp encode_params(%{types: types}, %{portal: param_oids}, params) do
     zipped = Enum.zip(param_oids, params)
 
     Enum.map(zipped, fn
@@ -467,6 +525,32 @@ defmodule Postgrex.Protocol do
     {command, List.last(nums)}
   end
 
+  defp msg_recv({:gen_tcp, sock}, :active_once, timeout) do
+    receive do
+      {:tcp, ^sock, buffer} ->
+        msg_recv(sock, buffer, timeout)
+      {:tcp_closed, ^sock} ->
+        {:error, :closed}
+      {:tcp_error, ^sock, reason} ->
+        {:error, reason}
+    after
+      timeout ->
+        {:error, timeout}
+    end
+  end
+  defp msg_recv({:ssl, sock}, :active_once, timeout) do
+    receive do
+      {:ssl, ^sock, buffer} ->
+        msg_recv(sock, buffer, timeout)
+      {:ssl_closed, ^sock} ->
+        {:error, :closed}
+      {:ssl_error, ^sock, reason} ->
+        {:error, reason}
+    after
+      timeout ->
+        {:error, timeout}
+    end
+  end
   defp msg_recv(sock, buffer, timeout) do
     case msg_decode(buffer) do
       {:ok, _, _} = ok -> ok
@@ -513,20 +597,95 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp send_to_result(msg, s) do
-    case msg_send(msg, s) do
+  ## TODO: See if :binary.copy/1 of parameters/notifications reduces memory
+  defp handle_msg(status, msg_parameter(name: name, value: value)) do
+    update_in(status.parameters, &Map.put(&1, name, value))
+  end
+  defp handle_msg(status, msg_notify(channel: channel, payload: payload)) do
+    update_in(status.notifications, &[{channel, payload} | &1])
+  end
+  defp handle_msg(status, msg_notice()) do
+    # TODO: subscribers
+    status
+  end
+  defp handle_msg(status, msg_ready()) do
+    status
+  end
+
+  defp ok(%{sock: sock} = s, status, buffer) do
+    activate(sock, buffer)
+    %{parameters: parameters, notifications: notifications} = status
+    {:ok, s, parameters, notifications}
+  end
+
+  defp ok(result, %{sock: sock} = s, status, buffer) do
+    activate(sock, buffer)
+    %{parameters: parameters, notifications: notifications} = status
+    {:ok, result, s, parameters, notifications}
+  end
+
+  defp error(reason, s) do
+    {:stop, reason, s}
+  end
+
+  defp error(reason, s, status, buffer) do
+    case msg_send(msg_sync(), s) do
       :ok ->
-        {:ok, s}
+        ok(reason, s, status, buffer)
       {:error, exception} ->
-        {:error, exception , s}
+        error(exception, s)
     end
   end
 
-  defp exit_reply(kind, reason, stack) do
-    {:exit, exit_reason(kind, reason, stack)}
+  defp sync_exit(kind, reason, stack, s, status, buffer) do
+    case msg_send(msg_sync(), s) do
+      :ok ->
+        exit(kind, reason, stack, s, status, buffer)
+      {:error, exception} ->
+        error(exception, s)
+    end
+  end
+
+  defp exit(kind, reason, stack, s, status, buffer) do
+    result = {:exit, exit_reason(kind, reason, stack)}
+    ok(result, s, status, buffer)
   end
 
   defp exit_reason(:exit, reason, _), do: reason
   defp exit_reason(:error, reason, stack), do: {reason, stack}
   defp exit_reason(:throw, value, stack), do: {{:nocatch, value}, stack}
+
+  ## Fake [active: once] if buffer not empty and delay error/closed to next call
+  defp activate({:gen_tcp, sock}, <<>>) do
+    case :inet.setopts(sock, [active: :once]) do
+      :ok ->
+        :ok
+      {:error, :closed} ->
+        _ = send(self(), {:tcp_closed, sock})
+        :ok
+      {:error, reason} ->
+        _ = send(self(), {:tcp_error, sock, reason})
+        :ok
+    end
+  end
+  defp activate({:gen_tcp, sock}, buffer) do
+    _ = send(self(), {:tcp, sock, buffer})
+    :ok
+  end
+  defp activate({:ssl, sock}, <<>>) do
+    case :ssl.setopts(sock, [active: :once]) do
+      :ok ->
+        :ok
+      {:error, :closed} ->
+        _ = send(self(), {:ssl_closed, sock})
+        :ok
+      {:error, reason} ->
+        _ = send(self(), {:ssl_error, sock, reason})
+        :ok
+    end
+  end
+  defp activate({:ssl, sock}, buffer) do
+    _ = send(self(), {:ssl, sock, buffer})
+    :ok
+  end
 end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -38,8 +38,9 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  @spec checkout(state) :: {:ok, binary} | {:error, %Postgrex.Error{}}
-  def checkout(%{sock: {:gen_tcp, sock}} = s) do
+  @spec checkout(state, binary | :active_once) ::
+    {:ok, binary} | {:error, %Postgrex.Error{}}
+  def checkout(%{sock: {:gen_tcp, sock}} = s, :active_once) do
     case :inet.setopts(sock, [active: :false]) do
       :ok ->
         recv_buffer(s)
@@ -47,7 +48,7 @@ defmodule Postgrex.Protocol do
         error(%Postgrex.Error{message: "tcp recv: #{reason}"}, s)
     end
   end
-  def checkout(%{sock: {:ssl, sock}} = s) do
+  def checkout(%{sock: {:ssl, sock}} = s, :active_once) do
     case :ssl.setopts(sock, [active: :false]) do
       :ok ->
         recv_buffer(s)
@@ -55,6 +56,7 @@ defmodule Postgrex.Protocol do
         error(%Postgrex.Error{message: "tcp recv: #{reason}"}, s)
     end
   end
+  def checkout(_, buffer), do: {:ok, buffer}
 
   @spec checkin(state, binary) ::
     {:ok, parameters, notifications} | {:error, %Postgrex.Error{}}

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -8,13 +8,54 @@ defmodule Postgrex.Result do
     * `rows` - The result set. A list of tuples, each tuple corresponding to a
                row, each element in the tuple corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
+    * `decoder`  - Terms used to decode the query in the client;
   """
 
   @type t :: %__MODULE__{
     command:  atom,
     columns:  [String.t] | nil,
-    rows:     [[term]] | nil,
-    num_rows: integer}
+    rows:     [[term] | term] | nil,
+    num_rows: integer,
+    decoder:  {[Postgrex.Types.oid], Postgrex.Types.state} | :done}
 
-  defstruct [:command, :columns, :rows, :num_rows]
+  defstruct [command: nil, columns: nil, rows: nil, num_rows: nil,
+             decoder: :done]
+
+  @doc """
+  Decodes a result set.
+
+  It is a no-op if the result was already decoded.
+
+  A mapper function can be given to further process
+  each row, in no specific order.
+  """
+  @spec decode(t, ([term] -> term)) :: t
+  def decode(result_set, mapper \\ fn x -> x end)
+
+  def decode(%Postgrex.Result{decoder: :done} = res, _mapper), do: res
+
+  def decode(res, mapper) do
+    %Postgrex.Result{rows: rows, decoder: {col_oids, types}} = res
+    rows = decode(rows, col_oids, types, mapper)
+    %Postgrex.Result{res | rows: rows, decoder: :done}
+  end
+
+  defp decode(rows, col_oids, types, mapper) do
+    decoders = for oid <- col_oids, do: Postgrex.Types.decoder(oid, types)
+    do_decode(rows, decoders, mapper, [])
+  end
+
+  defp do_decode([row | rows], decoders, mapper, decoded) do
+    decoded = [mapper.(decode_row(row, decoders)) | decoded]
+    do_decode(rows, decoders, mapper, decoded)
+  end
+  defp do_decode([], _, _, decoded), do: decoded
+
+  defp decode_row([nil | rest], [_ | decoders]) do
+    [nil | decode_row(rest, decoders)]
+  end
+  defp decode_row([elem | rest], [decode | decoders]) do
+    [decode.(elem) | decode_row(rest, decoders)]
+  end
+  defp decode_row([], []), do: []
 end

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -1,37 +1,6 @@
 defmodule Postgrex.Utils do
   @moduledoc false
 
-  def error(error, %{state: :init}) do
-    {:stop, error}
-  end
-  def error(error, s) do
-    reply(error, s)
-    {:stop, error, s}
-  end
-
-  def reply(reply, %{queue: queue}) do
-    case :queue.out(queue) do
-      {:empty, _queue} ->
-        false
-      {{:value, %{from: nil}}, _queue} ->
-        false
-      {{:value, %{from: from}}, _queue} when elem(reply, 0) == :error ->
-        Connection.reply(from, reply)
-        true
-      {{:value, %{reply: :no_reply, from: from}}, _queue} ->
-        Connection.reply(from, reply)
-        true
-      {{:value, %{reply: {:reply, reply}, from: from}}, _queue} ->
-        Connection.reply(from, reply)
-        true
-    end
-  end
-
-  def reply(reply, {_, _} = from) do
-    Connection.reply(from, reply)
-    true
-  end
-
   @doc """
   Converts pg major.minor.patch (http://www.postgresql.org/support/versioning) version to an integer
   """

--- a/test/custom_extensions_test.exs
+++ b/test/custom_extensions_test.exs
@@ -79,13 +79,15 @@ defmodule CustomExtensionsTest do
   end
 
   test "encode and decode pushes error to client", context do
-    assert {{%RuntimeError{message: "encode"}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::boolean", [true]))
+    assert_raise RuntimeError, "encode", fn ->
+      query("SELECT $1::boolean", [true])
+    end
 
     assert Process.alive? context[:pid]
 
-    assert {{%RuntimeError{message: "decode"}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT true", []))
+    assert_raise RuntimeError, "decode", fn ->
+      query("SELECT true", [])
+    end
 
     assert Process.alive? context[:pid]
   end

--- a/test/notification_test.exs
+++ b/test/notification_test.exs
@@ -67,9 +67,4 @@ defmodule NotificationTest do
     assert {:ok, %Postgrex.Result{command: :notify}} = P.query(context.pid2, "NOTIFY channel", [])
     :timer.sleep(300)
   end
-
-  test "listen error", context do
-    assert {:error, %Postgrex.Error{}} = P.listen(context.pid, "\n")
-  end
-
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -476,6 +476,20 @@ defmodule QueryTest do
     assert res.rows == [[1, 2], [3, 4]]
   end
 
+  test "multi row result struct with manual decoding", context do
+    assert {:ok, res} = P.query(context[:pid], "VALUES (1, 2), (3, 4)", [], decode: :manual)
+    assert res.rows == [[<<0, 0, 0, 3>>, <<0, 0, 0, 4>>],
+      [<<0, 0, 0, 1>>, <<0, 0, 0, 2>>]]
+
+    assert Postgrex.Result.decode(res).rows == [[1, 2], [3, 4]]
+
+    res = Postgrex.Result.decode(res, &Enum.map(&1, fn x -> x * 2 end))
+    assert res.rows == [[2, 4], [6, 8]]
+
+    res = Postgrex.Result.decode(res, & &1 * 2)
+    assert res.rows == [[2, 4], [6, 8]]
+  end
+
   test "insert", context do
     :ok = query("CREATE TABLE test (id int, text text)", [])
     [] = query("SELECT * FROM test", [])

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -510,27 +510,4 @@ defmodule QueryTest do
       assert_receive [[:void]], 1000
     end)
   end
-
-  test "async query", context do
-    task1 = async_query("SELECT true, false", [])
-    task2 = async_query("SELECT 42", [])
-
-    {:ok, %Postgrex.Result{rows: rows}} = Task.await(task1)
-    assert [[true, false]] = rows
-
-    {:ok, %Postgrex.Result{rows: rows}} = Task.await(task2)
-    assert [[42]] = rows
-
-    context = Map.put(context, :pid, nil)
-
-    if function_exported?(GenServer, :whereis, 1) do
-      assert_raise ArgumentError, "no process is associated with nil", fn ->
-        async_query("SELECT 42", [])
-      end
-    else
-      assert_raise ArgumentError, "requires Elixir 1.1 when passing server name as first argument", fn ->
-        async_query("SELECT 42", [])
-      end
-    end
-  end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -508,4 +508,82 @@ defmodule QueryTest do
       assert_receive [[:void]], 1000
     end)
   end
+
+  test "active client timeout", context do
+    conn = context[:pid]
+
+    Process.flag(:trap_exit, true)
+    assert %Postgrex.Error{} = query("SELECT pg_sleep(0.1)", [], [timeout: 50])
+
+    assert_receive {:EXIT, ^conn, {:shutdown, :timeout}}
+  end
+
+  test "active client cancel", context do
+    conn = context[:pid]
+    :sys.suspend(conn)
+
+    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [queue_timeout: 0]))
+
+    Process.flag(:trap_exit, true)
+    :sys.resume(conn)
+
+    assert_receive {:EXIT, ^conn, {:shutdown, :cancel}}
+  end
+
+  test "active client DOWN", context do
+    self_pid = self
+    conn = context[:pid]
+
+    pid = spawn fn ->
+      send self_pid, query("SELECT pg_sleep(0.2)", [])
+    end
+
+    :timer.sleep(100)
+    Process.flag(:trap_exit, true)
+    Process.exit(pid, :shutdown)
+
+    assert_receive {:EXIT, ^conn, {:shutdown, :DOWN}}
+  end
+
+  test "queued client cancel", context do
+    self_pid = self
+    Enum.each(1..10, fn _ ->
+      spawn fn ->
+        send self_pid, query("SELECT pg_sleep(0.1)", [])
+      end
+    end)
+
+    assert_receive [[:void]], 1000
+
+    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [queue_timeout: 0]))
+    assert [[42]] = query("SELECT 42", [])
+
+     Enum.each(2..10, fn _ ->
+      assert_received [[:void]]
+    end)
+  end
+
+  test "queued client DOWN", context do
+    self_pid = self
+    Enum.each(1..10, fn _ ->
+      spawn fn ->
+        send self_pid, query("SELECT pg_sleep(0.1)", [])
+      end
+    end)
+
+    assert_receive [[:void]], 1000
+
+    pid = spawn fn ->
+      send self_pid, query("SELECT 42", [])
+    end
+
+    :timer.sleep(100)
+    Process.exit(pid, :shutdown)
+
+    assert [[42]] = query("SELECT 42", [])
+
+    Enum.each(2..10, fn _ ->
+      assert_received [[:void]]
+    end)
+  end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -192,11 +192,8 @@ defmodule QueryTest do
     # oid's range is 0 to 4294967295
     assert [[0]] = query("select $1::oid;", [0])
     assert [[4294967295]] = query("select $1::oid;", [4294967295])
-
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::oid", [0 - 1]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::oid", [4294967295 + 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::oid", [0 - 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::oid", [4294967295 + 1]))
 
     assert [["-"]] = query("select $1::regproc::text;", [0])
     assert [["regprocin"]] = query("select $1::regproc::text;", [44])
@@ -221,14 +218,12 @@ defmodule QueryTest do
   end
 
   test "encoding oids as binary fails with a helpful error message", context do
-    assert {{%Postgrex.Error{message: message}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("select $1::regclass;", ["pg_type"]))
+    assert %Postgrex.Error{message: message} = catch_error(query("select $1::regclass;", ["pg_type"]))
     assert message =~ "See https://github.com/ericmj/postgrex#oid-type-encoding"
   end
 
   test "fail on encoding wrong value", context do
-    assert {{%ArgumentError{message: message}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::integer", ["123"]))
+    assert %ArgumentError{message: message} = catch_error(query("SELECT $1::integer", ["123"]))
     assert message =~ "Postgrex expected a term that can be encoded/cast to type \"int4\""
   end
 
@@ -289,26 +284,20 @@ defmodule QueryTest do
     # int2's range is -32768 to +32767
     assert [[-32768]] = query("SELECT $1::int2", [-32768])
     assert [[32767]] = query("SELECT $1::int2", [32767])
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int2", [32767 + 1]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int2", [-32768 - 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int2", [32767 + 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int2", [-32768 - 1]))
 
     # int4's range is -2147483648 to +2147483647
     assert [[-2147483648]] = query("SELECT $1::int4", [-2147483648])
     assert [[2147483647]] = query("SELECT $1::int4", [2147483647])
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int4", [2147483647 + 1]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int4", [-2147483648 - 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int4", [2147483647 + 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int4", [-2147483648 - 1]))
 
     # int8's range is  -9223372036854775808 to 9223372036854775807
     assert [[-9223372036854775808]] = query("SELECT $1::int8", [-9223372036854775808])
     assert [[9223372036854775807]] = query("SELECT $1::int8", [9223372036854775807])
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int8", [9223372036854775807 + 1]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int8", [-9223372036854775808 - 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int8", [9223372036854775807 + 1]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int8", [-9223372036854775808 - 1]))
   end
 
   test "encode uuid", context do
@@ -411,18 +400,14 @@ defmodule QueryTest do
     # int4's range is -2147483648 to +2147483647
     assert [[%Postgrex.Range{lower: -2147483648}]] = query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483648}])
     assert [[%Postgrex.Range{upper: 2147483647}]] = query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483647, upper_inclusive: false}])
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483649}]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483648}]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int4range", [%Postgrex.Range{lower: -2147483649}]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int4range", [%Postgrex.Range{upper: 2147483648}]))
 
     # int8's range is -9223372036854775808 to 9223372036854775807
     assert [[%Postgrex.Range{lower: -9223372036854775807}]] = query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775807}])
     assert [[%Postgrex.Range{upper: 9223372036854775806}]] = query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775806, upper_inclusive: false}])
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775809}]))
-    assert {{%ArgumentError{}, _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775808}]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int8range", [%Postgrex.Range{lower: -9223372036854775809}]))
+    assert %ArgumentError{} = catch_error(query("SELECT $1::int8range", [%Postgrex.Range{upper: 9223372036854775808}]))
   end
 
   @tag min_pg_version: "9.0"
@@ -446,10 +431,9 @@ defmodule QueryTest do
   end
 
   test "fail on encode arrays", context do
-    assert {{%ArgumentError{message: "nested lists must have lists with matching lengths"},
-        _}, {P, :query, [_|_]}} =
-      catch_exit(query("SELECT $1::integer[]", [[[1], [1,2]]]))
-
+    assert_raise ArgumentError, "nested lists must have lists with matching lengths", fn ->
+      query("SELECT $1::integer[]", [[[1], [1,2]]])
+    end
     assert [[42]] = query("SELECT 42", [])
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -111,12 +111,6 @@ defmodule Postgrex.TestHelper do
     end
   end
 
-  defmacro async_query(stat, params) do
-    quote do
-      Postgrex.Connection.async_query(var!(context)[:pid], unquote(stat), unquote(params))
-    end
-  end
-
   def capture_log(fun) do
     Logger.remove_backend(:console)
     fun.()


### PR DESCRIPTION
Warning: This PR is missing tests for its new queue functionality.

Currently in Postgrex a query is carried out in the Connection process. This means the client has to copy statement/params to the Connection and the Connection has to copy the result to the client. The result might be large and can take a significant time to decode.

There are two steps in Postgrex to decoding the result. First the tcp stream is decoded into tuple packets based on the postgresql binary protocol and then the tuples are converted into relevant terms based on postgrex extensions. Converting from the tuple packet to a relevant term is the slowest of those two steps.

This PR moves the socket communication from the Connection process to the client process. This means that terms do not need to be copied between processes. It also allows the tuple packet to term conversion to be delayed so that the socket is returned to the Connection process (and perhaps its pool) before decoding the result. Therefore expensive decoding no longer blocks the Connection.

Ecto does a 3rd decoding step to convert the rows to structs. For example to fetch a 1000 rows the query time (in ecto logging terms) might be `51.5ms`. If we split the query time into query time by postgrex and the ecto decoding we get query time of `27.5ms` and decode time of `24ms`. This means the connection is blocked for `27.5ms`.

By applying this PR we can might get a query time of `44.4ms`. If we split the query time like before, except we can now do the 2nd decoding step (tuple packet to term) and ecto decoding in the client without blocking the connection, we get a query time of `5ms` and decode time of `39.4ms`. This means the connection is only blocked for `5ms` - instead of `27.5ms`.

Cons:

* While the client is using the socket the Connection can not use the socket. The connection starts a timer when it passes control to the client and if the timer fires it closes the socket. Then when the client process tries to send or recv from the socket it will be closed. Therefore a timeout will look like the socket closed with `Postgrex.Connection.query` returning an `:error` tuple. This is a pro and a con: the error isn't as clear as we'd like but the timeout can be handled cleanly as there is no exception, exit nor unhandled messages.

* If the client exits when it is in control of the socket the status of the socket is unknown and so the socket must be closed.

* If the Connection is used for queries and listening queries may temporarily delay notifications. It should be possible to handle this case better if desired by checking the pid of the receiving process and if it is a client forwarding the notifications to the Connection.

* The Connection process is more complex: there is a monitored queue and the socket switches between different active modes to handle queries, notifications and to listen/unlisten. The complexity could be reduced by splitting the listening functionality into an independent process.