### PR TITLE
Cache extension info when decoding

### DIFF
--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -272,6 +272,17 @@ defmodule Postgrex.Types do
     extension.decode(info, binary, state, opts)
   end
 
+  @doc """
+  Creates a fun that decodes a binary to an Elixir value for
+  the given type.
+  """
+  @spec decoder(oid, state) :: (binary -> term)
+  def decoder(oid, state) do
+    {_oid, info, extension} = fetch!(state, oid)
+    opts = fetch_opts(state, extension)
+    &extension.decode(info, &1, state, opts)
+  end
+
   defp fetch!(table, oid) do
     case :ets.lookup(table, oid) do
       [value] ->


### PR DESCRIPTION
On master the TypeInfo struct and the extension options are copied from ETS for every term in every row, which means row x column lookups. As this information is the same for every row it is more efficient to lookup this information once per column, i.e. 1 x column lookups. The gain here is not just in terms of skipping the lookup time but less garbage is created because terms are copied from ETS to the calling process on lookup.

I rewrote the `decode_rows/3` function to be slightly more efficient too.