### PR TITLE
Allow encoding parameters without blocking connection

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -102,11 +102,11 @@ defmodule Postgrex.Connection do
   end
 
   @doc """
-  Parses an (extended) query and returns the result as
+  Prepares an (extended) query and returns the result as
   `{:ok, %Postgrex.Query{}}` or `{:error, %Postgrex.Error{}}` if there was an
   error. Parameters can be set in the query as `$1` embedded in the query
-  string. To execute the query call `execute/4`. To close the parsed query call
-  `close/3`. See `Postgrex.Query` for the query data.
+  string. To execute the query call `execute/4`. To close the prepared query
+  call `close/3`. See `Postgrex.Query` for the query data.
 
   ## Options
 
@@ -115,29 +115,29 @@ defmodule Postgrex.Connection do
 
   ## Examples
 
-      Postgrex.Connection.parse(pid, "CREATE TABLE posts (id serial, title text)")
+      Postgrex.Connection.prepare(pid, "CREATE TABLE posts (id serial, title text)")
   """
-  @spec parse(pid, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Postgrex.Error.t}
-  def parse(pid, name, statement, opts \\ []) do
-    run(pid, &Protocol.parse(&1, name, statement, &2), opts)
+  @spec prepare(pid, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Postgrex.Error.t}
+  def prepare(pid, name, statement, opts \\ []) do
+    run(pid, &Protocol.prepare(&1, name, statement, &2), opts)
   end
 
   @doc """
-  Parsed an (extended) query and returns the parsed query or raises
-  `Postgrex.Error` if there was an error. See `parse/4`.
+  Prepared an (extended) query and returns the prepared query or raises
+  `Postgrex.Error` if there was an error. See `prepare/4`.
   """
-  @spec parse!(pid, iodata, iodata, Keyword.t) :: Postgrex.Query.t
-  def parse!(pid, name, statement, opts \\ []) do
-    case parse(pid, name, statement, opts) do
+  @spec prepare!(pid, iodata, iodata, Keyword.t) :: Postgrex.Query.t
+  def prepare!(pid, name, statement, opts \\ []) do
+    case prepare(pid, name, statement, opts) do
       {:ok, query}  -> query
       {:error, err} -> raise err
     end
   end
 
   @doc """
-  Runs an (extended) parsed query and returns the result as
+  Runs an (extended) prepared query and returns the result as
   `{:ok, %Postgrex.Result{}}` or `{:error, %Postgrex.Error{}}` if there was an
-  error. Parameters are given as part of the parsed query, `%Postgrex.Query{}`.
+  error. Parameters are given as part of the prepared query, `%Postgrex.Query{}`.
   See the README for information on how Postgrex encodes and decodes Elixir
   values by default. See `Postgrex.Query` for the query data and
   `Postgrex.Result` for the result data.
@@ -150,10 +150,10 @@ defmodule Postgrex.Connection do
 
   ## Examples
 
-      query = Postgrex.Connection.parse!(pid, "CREATE TABLE posts (id serial, title text)")
+      query = Postgrex.Connection.prepare!(pid, "CREATE TABLE posts (id serial, title text)")
       Postgrex.Connection.execute(pid, query)
 
-      query = Postgrex.Connection.parse!(pid, "SELECT id FROM posts WHERE title like $1")
+      query = Postgrex.Connection.prepare!(pid, "SELECT id FROM posts WHERE title like $1")
       Postgrex.Connection.execute(pid, %Postgrex.Query{query | params: ["%my%"]}
   """
   def execute(pid, query, opts \\ []) do
@@ -162,7 +162,7 @@ defmodule Postgrex.Connection do
   end
 
   @doc """
-  Runs an (extended) parsed query and returns the result or raises
+  Runs an (extended) prepared query and returns the result or raises
   `Postgrex.Error` if there was an error. See `execute/3`.
   """
   @spec execute!(pid, Postgrex.Query.t, Keyword.t) :: Postgrex.Result.t
@@ -174,9 +174,9 @@ defmodule Postgrex.Connection do
   end
 
   @doc """
-  Closes an (extended) parsed query and returns `:ok` or
+  Closes an (extended) prepared query and returns `:ok` or
   `{:error, %Postgrex.Error{}}` if there was an error. Closing a query releases
-  any resources held by postgresql for a parsed query with that name. See
+  any resources held by postgresql for a prepared query with that name. See
   `Postgrex.Query` for the query data.
 
   ## Options
@@ -185,7 +185,7 @@ defmodule Postgrex.Connection do
 
   ## Examples
 
-      query = Postgrex.Connection.parse!(pid, "CREATE TABLE posts (id serial, title text)")
+      query = Postgrex.Connection.prepare!(pid, "CREATE TABLE posts (id serial, title text)")
       Postgrex.Connection.close(pid, query)
   """
   @spec close(pid, Postgrex.Query.t, Keyword.t) :: :ok | {:error, Postgrex.Error.t}
@@ -194,8 +194,8 @@ defmodule Postgrex.Connection do
   end
 
   @doc """
-  Closes an (extended) parsed query and returns `:ok` or raises `Postgrex.Error`
-  if there was an error. See `close/3`.
+  Closes an (extended) prepared query and returns `:ok` or raises
+  `Postgrex.Error` if there was an error. See `close/3`.
   """
   @spec close!(pid, Postgrex.Query.t, Keyword.t) :: :ok
   def close!(pid, query, opts \\ []) do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -61,7 +61,7 @@ defmodule Postgrex.Protocol do
   def query(s, statement, params, buffer) do
     status = %{parameters: %{}, notifications: [], ok: :status,
                sync: :close_sync}
-    case parse_send(s, status, "", statement, buffer) do
+    case prepare_send(s, status, "", statement, buffer) do
       {:ok, %Query{} = query, status, buffer} ->
         query_encode(s, %{status | ok: :result}, query, params, buffer)
       {:ok, result, status, buffer} ->
@@ -71,13 +71,13 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  @spec parse(state, iodata, iodata, binary | :active_once) ::
+  @spec prepare(state, iodata, iodata, binary | :active_once) ::
     {:ok, Postgrex.Query.t | Postgrex.Error.t |
       {:error | :throw | :exit, any, list}, parameters, notifications, binary} |
     {:error, Postgrex.Error.t}
-  def parse(s, name, statement, buffer) do
+  def prepare(s, name, statement, buffer) do
     status = %{parameters: %{}, notifications: [], ok: :result}
-    parse_send(s, status, name, statement, buffer)
+    prepare_send(s, status, name, statement, buffer)
   end
 
   @spec execute(state, Postgrex.Query.t, binary | :active_once) ::
@@ -345,9 +345,9 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  ## parse
+  ## prepare
 
-  defp parse_send(s, status, name, statement, buffer) do
+  defp prepare_send(s, status, name, statement, buffer) do
     msgs = [
       msg_parse(name: name, statement: statement, type_oids: []),
       msg_describe(type: :statement, name: name),

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -1,0 +1,75 @@
+defmodule Postgrex.Query do
+  @moduledoc """
+  Query struct returned from a successfully parsed query. Its fields are:
+
+    * `name` - The name of the parsed statement;
+    * `statement` - The parsed statement;
+    * `params` - The parameters of the query.
+    * `param_formats` - List of formats for each parameters encoded to;
+    * `encoders` - List of anonymous functions to encode each parameter;
+    * `columns` - The column names;
+    * `result_formats` - List of formats for each column is decoded from;
+    * `decoders` - List of anonymous functions to decode each column;
+  """
+
+  import Postgrex.BinaryUtils
+
+  @type t :: %__MODULE__{
+    name:           iodata,
+    statement:      iodata,
+    params:         [term] | nil,
+    param_formats:  [:binary | :text] | nil,
+    encoders:       [(term -> iodata)] | nil,
+    columns:        [String.t] | nil,
+    result_formats: [:binary | :text] | nil,
+    decoders:       [(binary -> term)] | nil}
+
+  defstruct [:name, :statement, :params, :param_formats, :encoders, :columns,
+    :result_formats, :decoders]
+
+  @doc """
+  Encodes a parsed query..
+
+  It is a no-op if the parameters are already encoded.
+
+  A mapper function can be given to process each
+  parameter before encoding, in no specific order.
+  """
+  @spec encode(t, (term -> term)) :: t
+  def encode(query, mapper \\ fn x -> x end)
+
+  def encode(%Postgrex.Query{params: [_|_], param_formats: nil}, _mapper) do
+    raise ArgumentError, "parameters must be of length 0 for this query"
+  end
+
+  def encode(%Postgrex.Query{encoders: nil} = query, _mapper), do: query
+
+  def encode(%Postgrex.Query{encoders: [_|_] = encoders, params: nil}, _mapper) do
+    raise ArgumentError, "parameters must be of length #{length encoders} for this query"
+  end
+
+  def encode(query, mapper) do
+    %Postgrex.Query{params: params, encoders: encoders} = query
+    case encode_params(params, encoders, mapper, []) do
+      :error ->
+        raise ArgumentError, "parameters must be of length #{length encoders} for this query"
+      params ->
+       %Postgrex.Query{query | params: params, encoders: nil}
+    end
+  end
+
+  ## helpers
+
+  defp encode_params([param | params], [encoder | encoders], mapper, encoded) do
+    case mapper.(param) do
+      nil   ->
+        encode_params(params, encoders, mapper, [<<-1::int32>> | encoded])
+      param ->
+        param = encoder.(param)
+        encoded = [[<<IO.iodata_length(param)::int32>> | param] | encoded]
+        encode_params(params, encoders, mapper, encoded)
+    end
+  end
+  defp encode_params([], [], _, encoded), do: Enum.reverse(encoded)
+  defp encode_params(params, _, _, _) when is_list(params), do: :error
+end

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -1,9 +1,9 @@
 defmodule Postgrex.Query do
   @moduledoc """
-  Query struct returned from a successfully parsed query. Its fields are:
+  Query struct returned from a successfully prepared query. Its fields are:
 
-    * `name` - The name of the parsed statement;
-    * `statement` - The parsed statement;
+    * `name` - The name of the prepared statement;
+    * `statement` - The prepared statement;
     * `params` - The parameters of the query.
     * `param_formats` - List of formats for each parameters encoded to;
     * `encoders` - List of anonymous functions to encode each parameter;
@@ -28,7 +28,7 @@ defmodule Postgrex.Query do
     :result_formats, :decoders]
 
   @doc """
-  Encodes a parsed query..
+  Encodes a prepared query.
 
   It is a no-op if the parameters are already encoded.
 

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -16,7 +16,7 @@ defmodule Postgrex.Result do
     columns:  [String.t] | nil,
     rows:     [[term] | term] | nil,
     num_rows: integer,
-    decoders: [(term -> term)] | nil}
+    decoders: [(binary -> term)] | nil}
 
   defstruct [command: nil, columns: nil, rows: nil, num_rows: nil,
              decoders: nil]

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -441,6 +441,11 @@ defmodule QueryTest do
     assert_raise ArgumentError, "parameters must be of length 1 for this query", fn ->
       query("SELECT $1::integer", [1, 2])
     end
+
+    assert_raise ArgumentError, "parameters must be of length 0 for this query", fn ->
+      query("SELECT 42", [1])
+    end
+
     assert [[42]] = query("SELECT 42", [])
   end
 
@@ -488,6 +493,48 @@ defmodule QueryTest do
     [[42, "fortytwo"]] = query("SELECT * FROM test", [])
   end
 
+  test "parse, execute and close", context do
+    assert (%Postgrex.Query{} = query) = parse("42", "SELECT 42")
+    assert [[42]] = execute(query)
+    assert [[42]] = execute(query)
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "execute with automatic encoding", context do
+    assert (%Postgrex.Query{} = query) = parse("auto", "SELECT $1::int")
+    assert [[41]] = execute(%Postgrex.Query{query | params: [41]})
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "execute with manual encoding", context do
+    assert (%Postgrex.Query{} = query) = parse("manual", "SELECT $1::int")
+    query = %Postgrex.Query{query | params: [41]}
+    assert (%Postgrex.Query{} = query) = Postgrex.Query.encode(query)
+    assert Postgrex.Query.encode(query) == query
+    assert [[41]] = execute(query)
+    assert :ok = close(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "manual encode parsed query without params", context do
+    assert (%Postgrex.Query{} = query) = parse("42", "SELECT 42")
+    assert (%Postgrex.Query{} = query) = Postgrex.Query.encode(query)
+
+    query = %Postgrex.Query{query | params: []}
+    assert (%Postgrex.Query{} = query) = Postgrex.Query.encode(query)
+
+    assert [[42]] = execute(query)
+    assert :ok = close(query)
+  end
+
+  test "closing parsed query that does not exist succeeds", context do
+    assert (%Postgrex.Query{} = query) = parse("42", "SELECT 42")
+    assert :ok = close(query)
+    assert :ok = close(query)
+  end
+
   test "error codes are translated", context  do
     assert %Postgrex.Error{postgres: %{code: :syntax_error}} = query("wat", [])
   end
@@ -511,6 +558,62 @@ defmodule QueryTest do
       query("SELECT 42", [])
     assert :ok = query("ROLLBACK", [])
     assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "connection works after failure in parse", context do
+    assert %Postgrex.Error{} = parse("bad", "wat")
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "connection works after failure in execute", context do
+    %Postgrex.Query{} = query = parse("unique", "insert into uniques values (1), (1);")
+    assert %Postgrex.Error{postgres: %{code: :unique_violation}} =
+      execute(query)
+    assert %Postgrex.Error{postgres: %{code: :unique_violation}} =
+      execute(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "execute on closed parsed query fails", context do
+    assert (%Postgrex.Query{} = query) = parse("42", "SELECT 42")
+    assert :ok = close(query)
+    assert %Postgrex.Error{postgres: %{code: :invalid_sql_statement_name}} =
+      execute(query)
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "connection closes nameless parsed query after query", context do
+    %Postgrex.Query{} = query = parse("", "SELECT 41")
+    assert [[42]] = query("SELECT 42", [])
+    assert %Postgrex.Error{postgres: %{code: :invalid_sql_statement_name}} =
+      execute(query)
+  end
+
+  test "connection closes nameless parsed query after failure in parsing state", context do
+    %Postgrex.Query{} = query = parse("", "SELECT 41")
+    assert %Postgrex.Error{} = query("wat", [])
+    assert %Postgrex.Error{postgres: %{code: :invalid_sql_statement_name}} =
+      execute(query)
+  end
+
+  test "connection closes nameless parsed query after failure in executing state", context do
+    %Postgrex.Query{} = query = parse("", "SELECT 41")
+    assert %Postgrex.Error{} = query("wat", [])
+    assert %Postgrex.Error{postgres: %{code: :invalid_sql_statement_name}} =
+      execute(query)
+  end
+
+  test "connection closes nameless parsed query after failure during transaction query", context do
+    assert :ok = query("BEGIN", [])
+    %Postgrex.Query{} = query = parse("", "SELECT 41")
+    assert %Postgrex.Error{postgres: %{code: :unique_violation}} =
+      query("insert into uniques values (1), (1);", [])
+    assert %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}} =
+      query("SELECT 42", [])
+    %Postgrex.Query{} = rollback = parse("rollback", "ROLLBACK")
+    assert :ok = execute(rollback)
+    assert %Postgrex.Error{postgres: %{code: :invalid_sql_statement_name}} =
+      execute(query)
   end
 
   test "async test", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -111,9 +111,9 @@ defmodule Postgrex.TestHelper do
     end
   end
 
-  defmacro parse(name, stat, opts \\ []) do
+  defmacro prepare(name, stat, opts \\ []) do
     quote do
-      case Postgrex.Connection.parse(var!(context)[:pid], unquote(name),
+      case Postgrex.Connection.prepare(var!(context)[:pid], unquote(name),
                                      unquote(stat), unquote(opts)) do
         {:ok, %Postgrex.Query{} = query} -> query
         {:error, %Postgrex.Error{} = err} -> err

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -111,6 +111,37 @@ defmodule Postgrex.TestHelper do
     end
   end
 
+  defmacro parse(name, stat, opts \\ []) do
+    quote do
+      case Postgrex.Connection.parse(var!(context)[:pid], unquote(name),
+                                     unquote(stat), unquote(opts)) do
+        {:ok, %Postgrex.Query{} = query} -> query
+        {:error, %Postgrex.Error{} = err} -> err
+      end
+    end
+  end
+
+  defmacro execute(query, opts \\ []) do
+    quote do
+      case Postgrex.Connection.execute(var!(context)[:pid], unquote(query),
+                                       unquote(opts)) do
+        {:ok, %Postgrex.Result{rows: nil}} -> :ok
+        {:ok, %Postgrex.Result{rows: rows}} -> rows
+        {:error, %Postgrex.Error{} = err} -> err
+      end
+    end
+  end
+
+  defmacro close(query, opts \\ []) do
+    quote do
+      case Postgrex.Connection.close(var!(context)[:pid], unquote(query),
+                                     unquote(opts)) do
+        :ok -> :ok
+        {:error, %Postgrex.Error{} = err} -> err
+      end
+    end
+  end
+
   def capture_log(fun) do
     Logger.remove_backend(:console)
     fun.()


### PR DESCRIPTION
Currently queries are parse/described for every query and then connection is blocked while the parameters are encoded. This branch allows the statement to parsed as a separate action. The parsed query can then be used to encode parameters without blocking the connection and executed.

Parsed queries can be reused multiple times to encode parameters and execute. Everytime a parsed query is reused it saves a round trip to postgresql and allows postgresql to cache query plans if it can.

Once parsed queries are no longer needed they can be closed to free resources in postgresql.

As an optimisation a parsed query caches both encode and decode information so that executing a parsed query does not need to do any ETS lookups for most types.