### PR TITLE
Use DBConnection

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -8,6 +8,8 @@ defmodule Postgrex do
   def start(_, _) do
     import Supervisor.Spec
     opts = [strategy: :one_for_one, name: Postgrex.Supervisor]
-    Supervisor.start_link([worker(Postgrex.TypeServer, [])], opts)
+    children = [worker(Postgrex.TypeServer, []),
+                worker(Postgrex.Parameters, [])]
+    Supervisor.start_link(children, opts)
   end
 end

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -32,8 +32,6 @@ defmodule Postgrex.Connection do
     * `:password` - User password (default PGPASSWORD);
     * `:parameters` - Keyword list of connection parameters;
     * `:timeout` - Connect timeout in milliseconds (default: `#{@timeout}`);
-    * `:idle_timeout` - Idle timeout to ping postgres to maintain a connection
-    (default: `#{@idle_timeout}`)
     * `:ssl` - Set to `true` if ssl should be used (default: `false`);
     * `:ssl_opts` - A list of ssl options, see ssl docs;
     * `:socket_options` - Options to be given to the underlying socket;
@@ -41,6 +39,14 @@ defmodule Postgrex.Connection do
     * `:extensions` - A list of `{module, opts}` pairs where `module` is
       implementing the `Postgrex.Extension` behaviour and `opts` are the
       extension options;
+    * `:idle_timeout` - Idle timeout to ping postgres to maintain a connection
+    (default: `#{@idle_timeout}`)
+    * `:backoff_start` - The first backoff interval when reconnecting (default:
+    `200`);
+    * `:backoff_max` - The maximum backoff interval when reconnecting (default:
+    `15_000`);
+    * `:backoff_type` - The backoff strategy when reconnecting, `:stop` for no
+    backoff and to stop (see `:backoff`, default: `:jitter`)
     * `:transactions` - Set to `:strict` to error on unexpected transaction
     state, otherwise set to `naive` (default: `:naive`);
     * `:pool_mod` - The pool module to use, see `DBConnection`, it must be

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -7,14 +7,9 @@ defmodule Postgrex.Connection do
   you need to start a separate (notifications) connection.
   """
 
-  use Connection
-  alias Postgrex.Protocol
-  require Logger
+  alias Postgrex.Query
 
   @timeout 5000
-
-  defstruct [parameters: nil, protocol: nil, queue: :queue.new(), client: nil,
-             timer: nil]
 
   ### PUBLIC API ###
 
@@ -40,19 +35,7 @@ defmodule Postgrex.Connection do
   """
   @spec start_link(Keyword.t) :: {:ok, pid} | {:error, Postgrex.Error.t | term}
   def start_link(opts) do
-    Connection.start_link(__MODULE__, Postgrex.Utils.default_opts(opts))
-  end
-
-  @doc """
-  Stop the process and disconnect.
-
-  ## Options
-
-    * `:timeout` - Call timeout (default: `#{@timeout}`)
-  """
-  @spec stop(pid, Keyword.t) :: :ok
-  def stop(pid, opts \\ []) do
-    Connection.call(pid, :stop, opts[:timeout] || @timeout)
+    DBConnection.start_link(Postgrex.Protocol, Postgrex.Utils.default_opts(opts))
   end
 
   @doc """
@@ -82,7 +65,8 @@ defmodule Postgrex.Connection do
   """
   @spec query(pid, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(pid, statement, params, opts \\ []) do
-    run(pid, &Protocol.query(&1, statement, params, &2), opts)
+    query = %Query{name: "", statement: statement, params: params}
+    DBConnection.query(pid, query, opts)
   end
 
   @doc """
@@ -91,10 +75,8 @@ defmodule Postgrex.Connection do
   """
   @spec query!(pid, iodata, list, Keyword.t) :: Postgrex.Result.t
   def query!(pid, statement, params, opts \\ []) do
-    case query(pid, statement, params, opts) do
-      {:ok, res}    -> res
-      {:error, err} -> raise err
-    end
+    query = %Query{name: "", statement: statement, params: params}
+    DBConnection.query!(pid, query, opts)
   end
 
   @doc """
@@ -115,7 +97,7 @@ defmodule Postgrex.Connection do
   """
   @spec prepare(pid, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Postgrex.Error.t}
   def prepare(pid, name, statement, opts \\ []) do
-    run(pid, &Protocol.prepare(&1, name, statement, &2), opts)
+    DBConnection.prepare(pid, %Query{name: name, statement: statement}, opts)
   end
 
   @doc """
@@ -124,10 +106,7 @@ defmodule Postgrex.Connection do
   """
   @spec prepare!(pid, iodata, iodata, Keyword.t) :: Postgrex.Query.t
   def prepare!(pid, name, statement, opts \\ []) do
-    case prepare(pid, name, statement, opts) do
-      {:ok, query}  -> query
-      {:error, err} -> raise err
-    end
+    DBConnection.prepare!(pid, %Query{name: name, statement: statement}, opts)
   end
 
   @doc """
@@ -152,9 +131,10 @@ defmodule Postgrex.Connection do
       query = Postgrex.Connection.prepare!(pid, "SELECT id FROM posts WHERE title like $1")
       Postgrex.Connection.execute(pid, %Postgrex.Query{query | params: ["%my%"]}
   """
+  @spec execute(pid, Postgrex.Query.t, Keyword.t) ::
+    {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def execute(pid, query, opts \\ []) do
-    query = Postgrex.Query.encode(query)
-    run(pid, &Protocol.execute(&1, query, &2), opts)
+    DBConnection.execute(pid, query, opts)
   end
 
   @doc """
@@ -163,10 +143,7 @@ defmodule Postgrex.Connection do
   """
   @spec execute!(pid, Postgrex.Query.t, Keyword.t) :: Postgrex.Result.t
   def execute!(pid, query, opts \\ []) do
-    case execute(pid, query, opts) do
-      {:ok, res}    -> res
-      {:error, err} -> raise err
-    end
+    DBConnection.execute!(pid, query, opts)
   end
 
   @doc """
@@ -186,7 +163,7 @@ defmodule Postgrex.Connection do
   """
   @spec close(pid, Postgrex.Query.t, Keyword.t) :: :ok | {:error, Postgrex.Error.t}
   def close(pid, query, opts \\ []) do
-    run(pid, &Protocol.close(&1, query, &2), opts)
+    DBConnection.close(pid, query, opts)
   end
 
   @doc """
@@ -195,294 +172,16 @@ defmodule Postgrex.Connection do
   """
   @spec close!(pid, Postgrex.Query.t, Keyword.t) :: :ok
   def close!(pid, query, opts \\ []) do
-    case close(pid, query, opts) do
-      :ok           -> :ok
-      {:error, err} -> raise err
-    end
+    DBConnection.close!(pid, query, opts)
   end
 
   @doc """
   Returns a cached map of connection parameters.
-
   ## Options
-
-    * `:timeout` - Call timeout (default: `#{@timeout}`)
+  * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
-  @spec parameters(pid, Keyword.t) :: map
+  @spec parameters(pid, Keyword.t) :: %{binary => binary}
   def parameters(pid, opts \\ []) do
-    Connection.call(pid, :parameters, opts[:timeout] || @timeout)
-  end
-
-  ### CONNECTION CALLBACKS ###
-
-  @doc false
-  def init(opts) do
-    if opts[:sync_connect] do
-      sync_connect(opts)
-    else
-      {:connect, :init, opts}
-    end
-  end
-
-  @doc false
-  def connect(_, opts) do
-    case Protocol.connect(opts) do
-      {:ok, protocol, parameters, _} ->
-        {:ok, %__MODULE__{protocol: protocol, parameters: parameters}}
-      {:error, reason} ->
-        {:stop, reason, opts}
-    end
-  end
-
-  @doc false
-  def format_status(:terminate, [_pdict, opts]) when is_list(opts) do
-    Keyword.put(opts, :password, :REDACTED)
-  end
-  def format_status(opt, [_pdict, s]) do
-    s = %{s | types: :types_removed}
-    if opt == :normal do
-      [data: [{'State', s}]]
-    else
-      s
-    end
-  end
-
-  @doc false
-  def handle_call(:stop, _, s) do
-    {:stop, :normal, :ok, s}
-  end
-
-  def handle_call(:parameters, _from, %{parameters: params} = s) do
-    {:reply, params, s}
-  end
-
-  def handle_call({:checkout, ref, timeout}, {pid, _} = from, %{client: nil} = s) do
-    monitor = Process.monitor(pid)
-    handle_next({:checkout, timeout}, from, %{s | client: {ref, monitor}})
-  end
-
-  def handle_call({:checkout, ref, timeout}, {pid, _} = from, %{queue: queue} = s) do
-    client = {ref, Process.monitor(pid)}
-    {:noreply, %{s | queue: :queue.in({{:checkout, timeout}, client, from}, queue)}}
-  end
-
-  def handle_call({:listen, channel}, from, %{client: nil} = s) do
-    handle_next({:listen, channel}, from, s)
-  end
-  def handle_call({:unlisten, ref}, from, %{client: nil} = s) do
-    handle_next({:unlisten, ref}, from, s)
-  end
-
-  def handle_call(request, from, %{queue: queue} = s) do
-    {:noreply, %{s | queue: :queue.in({request, nil, from}, queue)}}
-  end
-
-  @doc false
-  def handle_cast({:done, ref, new_parameters, _notifications, buffer}, %{client: {ref, _}} = s) do
-    %{parameters: parameters} = s
-    parameters = Map.merge(parameters, new_parameters)
-    handle_next(buffer, %__MODULE__{s | parameters: parameters})
-  end
-
-  def handle_cast({:update, ref, new_parameters, _notifications}, %{client: {ref, _}} = s) do
-    %{parameters: parameters} = s
-    parameters = Map.merge(parameters, new_parameters)
-    {:noreply, %__MODULE__{s | parameters: parameters}}
-  end
-
-  def handle_cast({:stop, ref}, %{client: {ref, _}} = s) do
-    {:stop, {:shutdown, :stop}, s}
-  end
-
-  def handle_cast({:cancel, ref}, %{client: {ref, _}} = s) do
-    {:stop, {:shutdown, :cancel}, s}
-  end
-  def handle_cast({:cancel, ref}, %{queue: queue} = s) do
-    cancel =
-      fn({_, {ref2, monitor}, _}) when ref === ref2 ->
-          Process.demonitor(monitor, [:flush])
-          false
-        (_) ->
-          true
-      end
-    {:noreply, %{s | queue: :queue.filter(cancel, queue)}}
-  end
-
-  @doc false
-  def handle_info({:DOWN, ref, :process, _, _}, %{client: {_, ref}} = s) do
-    {:stop, {:shutdown, :DOWN}, s}
-  end
-
-  def handle_info({:DOWN, _, :process, _, _} = down, s) do
-    filter_queue(down, s)
-  end
-
-  def handle_info({:timeout, timer, __MODULE__}, %{timer: timer} = s) when is_reference(timer) do
-    {:stop, {:shutdown, :timeout}, s}
-  end
-
-  def handle_info(msg, s) do
-    protocol_info(msg, s)
-  end
-
-  ### PRIVATE FUNCTIONS ###
-
-  defp run(pid, fun, opts) do
-    queue_timeout = opts[:queue_timeout] || @timeout
-    timeout = opts[:timeout] || @timeout
-    ref = make_ref()
-    try do
-      Connection.call(pid, {:checkout, ref, timeout}, queue_timeout)
-    catch
-      :exit, {_, {_, :call, [pid | _]}} = reason ->
-        Connection.cast(pid, {:cancel, ref})
-        exit(reason)
-    else
-      {:ok, protocol, pid, buffer} ->
-        protocol = %{protocol | timeout: timeout}
-        result = run(pid, ref, fun, protocol, buffer)
-        run_result(result, opts)
-      {:error, _} = error ->
-        error
-    end
-  end
-
-  defp run(pid, ref, fun, protocol, buffer) do
-    try do
-      fun.(protocol, buffer)
-    else
-      {:ok, result, parameters, notifications, buffer} ->
-        Connection.cast(pid, {:done, ref, parameters, notifications, buffer})
-        result
-      {:ok, parameters, notifications, buffer} ->
-        Connection.cast(pid, {:done, ref, parameters, notifications, buffer})
-        :ok
-      {:error, _} = error ->
-        Connection.cast(pid, {:stop, ref})
-        error
-    catch
-      kind, reason ->
-        stack = System.stacktrace()
-        Connection.cast(pid, {:stop, ref})
-        :erlang.raise(kind, reason, stack)
-    end
-  end
-
-  defp run_result(%Postgrex.Result{} = res, opts) do
-    case Keyword.get(opts, :decode, :auto) do
-      :auto   -> {:ok, Postgrex.Result.decode(res)}
-      :manual -> {:ok, res}
-    end
-  end
-  defp run_result({kind, reason, stack}, _) do
-    :erlang.raise(kind, reason, stack)
-  end
-  defp run_result(%Postgrex.Query{} = query, _), do: {:ok, query}
-  defp run_result(%Postgrex.Error{} = err, _), do: {:error, err}
-  defp run_result(:ok, _), do: :ok
-  defp run_result({:error, _} = err, _), do: err
-
-  defp sync_connect(opts) do
-    case connect(:init, opts) do
-      {:ok, _} = ok      -> ok
-      {:stop, reason, _} -> {:stop, reason}
-    end
-  end
-
-  defp handle_next(buffer, %{client: client, timer: timer, queue: queue} = s) do
-    _ = client && Process.demonitor(elem(client, 1), [:flush])
-    cancel_timer(timer)
-    {item, queue} = :queue.out(queue)
-    s = %{s | client: nil, timer: nil, queue: queue}
-    case item do
-      {:value, {request, client, from}} ->
-        handle_next(request, from, buffer, %{s | client: client})
-      :empty ->
-        checkin(buffer, s)
-    end
-  end
-
-  defp handle_next(request, from, buffer \\ :active_once, s)
-
-  defp handle_next({:checkout, timeout}, from, buffer, s) do
-    handle_checkout(timeout, from, buffer, s)
-  end
-
-  defp checkin(buffer, %{protocol: protocol} = s) do
-    case Protocol.checkin(protocol, buffer) do
-      :ok              -> {:noreply, s}
-      {:error, reason} -> {:stop, reason, s}
-    end
-  end
-
-  defp handle_checkout(timeout, from, buffer, %{protocol: protocol} = s) do
-    case Protocol.checkout(protocol, buffer) do
-      {:ok, buffer} ->
-        Connection.reply(from, {:ok, protocol, self(), buffer})
-        timer = start_timer(timeout)
-        {:noreply,  %{s | timer: timer}}
-      {:error, reason} ->
-        {:stop, reason, s}
-    end
-  end
-
-  defp filter_queue({:DOWN, ref, :process, _, _} = msg, %{queue: queue} = s) do
-    len = :queue.len(queue)
-
-    down =
-      fn({_, {_, monitor}, _}) when ref === monitor ->
-          false
-        (_) ->
-          true
-      end
-
-    queue = :queue.filter(down, queue)
-
-    case :queue.len(queue) do
-      ^len ->
-        protocol_info(msg, s)
-      _ ->
-        {:noreply, %{s | queue: queue}}
-    end
-  end
-
-  defp protocol_info(info, s) do
-    %__MODULE__{protocol: protocol, parameters: parameters} = s
-    case Protocol.message(protocol, info) do
-      {:ok, new_parameters, _notifications} ->
-        parameters = Map.merge(parameters, new_parameters)
-        {:noreply, %__MODULE__{s | parameters: parameters}}
-      :unknown ->
-        Logger.info fn() ->
-          [inspect(__MODULE__), ?\s, inspect(self()), " received message: " |
-            inspect(info)]
-        end
-        {:noreply, s}
-      {:error, reason} ->
-        {:stop, reason, s}
-    end
-  end
-
-  defp start_timer(:infinity), do: nil
-  defp start_timer(timeout) do
-    :erlang.start_timer(timeout, self, __MODULE__)
-  end
-
-  defp cancel_timer(nil), do: :ok
-  defp cancel_timer(timer) do
-    case :erlang.cancel_timer(timer) do
-      false -> flush_timer(timer)
-      _     -> :ok
-    end
-  end
-
-  defp flush_timer(timer) do
-    receive do
-      {:timeout, ^timer, __MODULE__} ->
-        :ok
-    after
-      0 ->
-        raise ArgumentError, "Timer #{inspect(timer)} does not exist"
-    end
+    DBConnection.execute!(pid, %Postgrex.Parameters{}, opts)
   end
 end

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -79,10 +79,10 @@ defmodule Postgrex.Connection do
     (default: `#{@pool_timeout}`)
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Query request timeout (default: `#{@timeout}`);
-    * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
-    not (default: `:auto`)
-    * `:decode_mapper` - Fun to map each row in the result to a term, see
-    `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
+    * `:encode_mapper` - Fun to map each parameter before encoding, see
+    (default: `fn x -> x end`)
+    * `:decode_mapper` - Fun to map each row in the result to a term after
+    decoding, (default: `fn x -> x end`);
     * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
     * `:proxy` - The proxy module for the request, if any, see
@@ -176,10 +176,10 @@ defmodule Postgrex.Connection do
     (default: `#{@pool_timeout}`)
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Execute request timeout (default: `#{@timeout}`);
-    * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
-    not (default: `:auto`)
-    * `:decode_mapper` - Fun to map each row in the result to a term, see
-    `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
+    * `:encode_mapper` - Fun to map each parameter before encoding, see
+    (default: `fn x -> x end`)
+    * `:decode_mapper` - Fun to map each row in the result to a term after
+    decoding, (default: `fn x -> x end`);
     * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
     * `:proxy` - The proxy module for the request, if any, see

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -65,8 +65,8 @@ defmodule Postgrex.Connection do
   """
   @spec query(pid, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(pid, statement, params, opts \\ []) do
-    query = %Query{name: "", statement: statement, params: params}
-    DBConnection.query(pid, query, opts)
+    query = %Query{name: "", statement: statement}
+    DBConnection.query(pid, query, params, opts)
   end
 
   @doc """
@@ -75,8 +75,8 @@ defmodule Postgrex.Connection do
   """
   @spec query!(pid, iodata, list, Keyword.t) :: Postgrex.Result.t
   def query!(pid, statement, params, opts \\ []) do
-    query = %Query{name: "", statement: statement, params: params}
-    DBConnection.query!(pid, query, opts)
+    query = %Query{name: "", statement: statement}
+    DBConnection.query!(pid, query, params, opts)
   end
 
   @doc """
@@ -126,24 +126,24 @@ defmodule Postgrex.Connection do
   ## Examples
 
       query = Postgrex.Connection.prepare!(pid, "CREATE TABLE posts (id serial, title text)")
-      Postgrex.Connection.execute(pid, query)
+      Postgrex.Connection.execute(pid, query, [])
 
       query = Postgrex.Connection.prepare!(pid, "SELECT id FROM posts WHERE title like $1")
-      Postgrex.Connection.execute(pid, %Postgrex.Query{query | params: ["%my%"]}
+      Postgrex.Connection.execute(pid, query, ["%my%"])
   """
-  @spec execute(pid, Postgrex.Query.t, Keyword.t) ::
+  @spec execute(pid, Postgrex.Query.t, list, Keyword.t) ::
     {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
-  def execute(pid, query, opts \\ []) do
-    DBConnection.execute(pid, query, opts)
+  def execute(pid, query, params, opts \\ []) do
+    DBConnection.execute(pid, query, params, opts)
   end
 
   @doc """
   Runs an (extended) prepared query and returns the result or raises
-  `Postgrex.Error` if there was an error. See `execute/3`.
+  `Postgrex.Error` if there was an error. See `execute/4`.
   """
-  @spec execute!(pid, Postgrex.Query.t, Keyword.t) :: Postgrex.Result.t
-  def execute!(pid, query, opts \\ []) do
-    DBConnection.execute!(pid, query, opts)
+  @spec execute!(pid, Postgrex.Query.t, list, Keyword.t) :: Postgrex.Result.t
+  def execute!(pid, query, params, opts \\ []) do
+    DBConnection.execute!(pid, query, params, opts)
   end
 
   @doc """
@@ -177,11 +177,13 @@ defmodule Postgrex.Connection do
 
   @doc """
   Returns a cached map of connection parameters.
+
   ## Options
-  * `:timeout` - Call timeout (default: `#{@timeout}`)
+
+    * `:timeout` - Call timeout (default: `#{@timeout}`)
   """
   @spec parameters(pid, Keyword.t) :: %{binary => binary}
   def parameters(pid, opts \\ []) do
-    DBConnection.execute!(pid, %Postgrex.Parameters{}, opts)
+    DBConnection.execute!(pid, %Postgrex.Parameters{}, nil, opts)
   end
 end

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -69,6 +69,8 @@ defmodule Postgrex.Connection do
     not (default: `:auto`)
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
 
@@ -113,6 +115,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
 
@@ -151,6 +155,8 @@ defmodule Postgrex.Connection do
     not (default: `:auto`)
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
 
@@ -190,6 +196,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
 
@@ -236,10 +244,13 @@ defmodule Postgrex.Connection do
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    `DBConnection.Proxy` (default: `nil`);
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
-  transactions and requests.
+  transactions and requests. The `:pool_mod` and `:proxy_mod` will be used
+  for all requests inside the transaction function.
 
   ## Example
 

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -101,7 +101,12 @@ defmodule Postgrex.Connection do
   @spec query(conn, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(conn, statement, params, opts \\ []) do
     query = %Query{name: "", statement: statement}
-    DBConnection.query(conn, query, params, defaults(opts))
+    case DBConnection.query(conn, query, params, defaults(opts)) do
+      {:error, %ArgumentError{} = err} ->
+        raise err
+      other ->
+        other
+    end
   end
 
   @doc """
@@ -139,7 +144,13 @@ defmodule Postgrex.Connection do
   """
   @spec prepare(conn, iodata, iodata, Keyword.t) :: {:ok, Postgrex.Query.t} | {:error, Postgrex.Error.t}
   def prepare(conn, name, statement, opts \\ []) do
-    DBConnection.prepare(conn, %Query{name: name, statement: statement}, defaults(opts))
+    query = %Query{name: name, statement: statement}
+    case DBConnection.prepare(conn, query, defaults(opts)) do
+      {:error, %ArgumentError{} = err} ->
+        raise err
+      other ->
+        other
+    end
   end
 
   @doc """
@@ -184,7 +195,12 @@ defmodule Postgrex.Connection do
   @spec execute(conn, Postgrex.Query.t, list, Keyword.t) ::
     {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def execute(conn, query, params, opts \\ []) do
-    DBConnection.execute(conn, query, params, defaults(opts))
+    case DBConnection.execute(conn, query, params, defaults(opts)) do
+      {:error, %ArgumentError{} = err} ->
+        raise err
+      other ->
+        other
+    end
   end
 
   @doc """
@@ -221,7 +237,12 @@ defmodule Postgrex.Connection do
   """
   @spec close(conn, Postgrex.Query.t, Keyword.t) :: :ok | {:error, Postgrex.Error.t}
   def close(conn, query, opts \\ []) do
-    DBConnection.close(conn, query, defaults(opts))
+    case DBConnection.close(conn, query, defaults(opts)) do
+      {:error, %ArgumentError{} = err} ->
+        raise err
+      other ->
+        other
+    end
   end
 
   @doc """

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -14,8 +14,9 @@ defmodule Postgrex.Connection do
   """
   @type conn :: DBConnection.conn
 
-  @queue_timeout 5_000
+  @queue_timeout 5000
   @timeout 5000
+  @idle_timeout 5000
 
   ### PUBLIC API ###
 
@@ -31,6 +32,8 @@ defmodule Postgrex.Connection do
     * `:password` - User password (default PGPASSWORD);
     * `:parameters` - Keyword list of connection parameters;
     * `:timeout` - Connect timeout in milliseconds (default: `#{@timeout}`);
+    * `:idle_timeout` - Idle timeout to ping postgres to maintain a connection
+    (default: `#{@idle_timeout}`)
     * `:ssl` - Set to `true` if ssl should be used (default: `false`);
     * `:ssl_opts` - A list of ssl options, see ssl docs;
     * `:socket_options` - Options to be given to the underlying socket;

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -82,6 +82,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Query request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
+    * `:decode_mapper` - Fun to map each row in the result to a term, see
+    `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
     * `:proxy_mod` - The proxy module for the request, if any, see
@@ -179,6 +181,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Execute request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
+    * `:decode_mapper` - Fun to map each row in the result to a term, see
+    `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
     * `:proxy_mod` - The proxy module for the request, if any, see

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -40,6 +40,9 @@ defmodule Postgrex.Connection do
       extension options;
     * `:transactions` - Set to `:strict` to error on unexpected transaction
     state, otherwise set to `naive` (default: `:naive`);
+    * `:pool_mod` - Set the pool module to use, see `DBConnection`, it must be
+    included with all requests if not the default (default:
+    `DBConnection.Connection`);
   """
   @spec start_link(Keyword.t) :: {:ok, pid} | {:error, Postgrex.Error.t | term}
   def start_link(opts) do
@@ -64,6 +67,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Query request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
 
   ## Examples
 
@@ -106,6 +111,8 @@ defmodule Postgrex.Connection do
     * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
     as the call timeout (default: `true`);
     * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
 
   ## Examples
 
@@ -142,6 +149,8 @@ defmodule Postgrex.Connection do
     * `:timeout` - Execute request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
 
   ## Examples
 
@@ -179,6 +188,8 @@ defmodule Postgrex.Connection do
     * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
     as the call timeout (default: `true`);
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
 
   ## Examples
 
@@ -223,6 +234,8 @@ defmodule Postgrex.Connection do
     * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
     as the call timeout (default: `true`);
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
@@ -262,6 +275,9 @@ defmodule Postgrex.Connection do
   ## Options
 
     * `:timeout` - Call timeout (default: `#{@timeout}`)
+    * `:pool_mod` - The pool module to use, must match that set on
+    `start_link/1`, see `DBConnection`
+
   """
   @spec parameters(conn, Keyword.t) :: %{binary => binary}
   def parameters(conn, opts \\ []) do

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -43,7 +43,7 @@ defmodule Postgrex.Connection do
       extension options;
     * `:transactions` - Set to `:strict` to error on unexpected transaction
     state, otherwise set to `naive` (default: `:naive`);
-    * `:pool_mod` - Set the pool module to use, see `DBConnection`, it must be
+    * `:pool_mod` - The pool module to use, see `DBConnection`, it must be
     included with all requests if not the default (default:
     `DBConnection.Connection`);
   """
@@ -72,7 +72,7 @@ defmodule Postgrex.Connection do
     not (default: `:auto`)
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    * `:proxy_mod` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -118,7 +118,7 @@ defmodule Postgrex.Connection do
     * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    * `:proxy_mod` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -158,7 +158,7 @@ defmodule Postgrex.Connection do
     not (default: `:auto`)
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    * `:proxy_mod` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -199,7 +199,7 @@ defmodule Postgrex.Connection do
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    * `:proxy_mod` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -247,7 +247,7 @@ defmodule Postgrex.Connection do
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
     * `:pool_mod` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - Set the proxy module for the request, if any, see
+    * `:proxy_mod` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   The `:timeout` is for the duration of the transaction and all nested

--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -17,7 +17,7 @@ defmodule Postgrex.Connection do
   """
   @type conn :: DBConnection.conn
 
-  @queue_timeout 5000
+  @pool_timeout 5000
   @timeout 5000
   @idle_timeout 5000
 
@@ -55,7 +55,7 @@ defmodule Postgrex.Connection do
     backoff and to stop (see `:backoff`, default: `:jitter`)
     * `:transactions` - Set to `:strict` to error on unexpected transaction
     state, otherwise set to `naive` (default: `:naive`);
-    * `:pool_mod` - The pool module to use, see `DBConnection`, it must be
+    * `:pool` - The pool module to use, see `DBConnection`, it must be
     included with all requests if not the default (default:
     `DBConnection.Connection`);
   """
@@ -75,18 +75,17 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:queue_timeout` - Time to wait in the queue for the connection
-    (default: `#{@queue_timeout}`)
-    * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
-    as the call timeout (default: `true`);
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Query request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
     * `:decode_mapper` - Fun to map each row in the result to a term, see
     `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - The proxy module for the request, if any, see
+    * `:proxy` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -130,14 +129,13 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:queue_timeout` - Time to wait in the queue for the connection
-    (default: `#{@queue_timeout}`)
-    * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
-    as the call timeout (default: `true`);
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Prepare request timeout (default: `#{@timeout}`);
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - The proxy module for the request, if any, see
+    * `:proxy` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -174,18 +172,17 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:queue_timeout` - Time to wait in the queue for the connection
-    (default: `#{@queue_timeout}`)
-    * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
-    as the call timeout (default: `true`);
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Execute request timeout (default: `#{@timeout}`);
     * `:decode`  - Decode method: `:auto` decodes the result and `:manual` does
     not (default: `:auto`)
     * `:decode_mapper` - Fun to map each row in the result to a term, see
     `Postgrex.Result.decode/2`, (default: `fn x -> x end`);
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - The proxy module for the request, if any, see
+    * `:proxy` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -224,14 +221,13 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:queue_timeout` - Time to wait in the queue for the connection
-    (default: `#{@queue_timeout}`)
-    * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
-    as the call timeout (default: `true`);
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - The proxy module for the request, if any, see
+    * `:proxy` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   ## Examples
@@ -277,19 +273,18 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:queue_timeout` - Time to wait in the queue for the connection
-    (default: `#{@queue_timeout}`)
-    * `:queue` - Whether to wait in the queue, if false `:queue_timeout` acts
-    as the call timeout (default: `true`);
+    * `:pool_timeout` - Time to wait in the queue for the connection
+    (default: `#{@pool_timeout}`)
+    * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
-    * `:proxy_mod` - The proxy module for the request, if any, see
+    * `:proxy` - The proxy module for the request, if any, see
     `DBConnection.Proxy` (default: `nil`);
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
-  transactions and requests. The `:pool_mod` and `:proxy_mod` will be used
+  transactions and requests. The `:pool` and `:proxy` will be used
   for all requests inside the transaction function.
 
   ## Example
@@ -325,8 +320,8 @@ defmodule Postgrex.Connection do
 
   ## Options
 
-    * `:timeout` - Call timeout (default: `#{@timeout}`)
-    * `:pool_mod` - The pool module to use, must match that set on
+    * `:pool_timeout` - Call timeout (default: `#{@pool_timeout}`)
+    * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
 
   """

--- a/lib/postgrex/parameters.ex
+++ b/lib/postgrex/parameters.ex
@@ -1,0 +1,15 @@
+defmodule Postgrex.Parameters do
+  @moduledoc false
+  defstruct [parameters: nil]
+  @type t :: %__MODULE__{parameters: nil | %{binary => binary}}
+end
+
+defimpl DBConnection.Query, for: Postgrex.Parameters do
+  def parse(query, _), do: query
+  def describe(query, _), do: query
+  def encode(query, _), do: query
+end
+
+defimpl DBConnection.Result, for: Postgrex.Parameters do
+  def decode(%{parameters: parameters}, _), do: parameters
+end

--- a/lib/postgrex/parameters.ex
+++ b/lib/postgrex/parameters.ex
@@ -29,6 +29,11 @@ defmodule Postgrex.Parameters do
     end
   end
 
+  @spec delete(reference) :: :ok
+  def delete(ref) do
+    GenServer.cast(__MODULE__, {:delete, ref})
+  end
+
   @spec fetch(reference) :: {:ok, %{binary => binary}} | :error
   def fetch(ref) do
     try do
@@ -53,6 +58,11 @@ defmodule Postgrex.Parameters do
     ref = Process.monitor(pid)
     true = :ets.insert_new(state, {ref, parameters})
     {:reply, ref, state}
+  end
+
+  def handle_cast({:delete, ref}, state) do
+    :ets.delete(state, ref)
+    {:noreply, state}
   end
 
   def handle_info({:DOWN, ref, :process, _, _}, state) do

--- a/lib/postgrex/parameters.ex
+++ b/lib/postgrex/parameters.ex
@@ -1,15 +1,12 @@
 defmodule Postgrex.Parameters do
   @moduledoc false
-  defstruct [parameters: nil]
-  @type t :: %__MODULE__{parameters: nil | %{binary => binary}}
+  defstruct []
+  @type t :: %__MODULE__{}
 end
 
 defimpl DBConnection.Query, for: Postgrex.Parameters do
   def parse(query, _), do: query
   def describe(query, _), do: query
-  def encode(query, _), do: query
-end
-
-defimpl DBConnection.Result, for: Postgrex.Parameters do
-  def decode(%{parameters: parameters}, _), do: parameters
+  def encode(_, nil, _), do: nil
+  def decode(_, parameters, _), do: parameters
 end

--- a/lib/postgrex/parameters.ex
+++ b/lib/postgrex/parameters.ex
@@ -1,7 +1,64 @@
 defmodule Postgrex.Parameters do
   @moduledoc false
+
+  use GenServer
+
   defstruct []
   @type t :: %__MODULE__{}
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, nil, [name: __MODULE__])
+  end
+
+  @spec insert(%{binary => binary}) :: reference
+  def insert(parameters) do
+    GenServer.call(__MODULE__, {:insert, parameters})
+  end
+
+  @spec put(reference, binary, binary) :: boolean
+  def put(ref, name, value) do
+    try do
+      :ets.lookup_element(__MODULE__, ref, 2)
+    rescue
+      ArgumentError ->
+        false
+    else
+      parameters ->
+        parameters = Map.put(parameters, name, value)
+        :ets.update_element(__MODULE__, ref, {2, parameters})
+    end
+  end
+
+  @spec fetch(reference) :: {:ok, %{binary => binary}} | :error
+  def fetch(ref) do
+    try do
+      :ets.lookup_element(__MODULE__, ref, 2)
+    rescue
+      ArgumentError ->
+        :error
+    else
+      parameters ->
+        {:ok, parameters}
+    end
+  end
+
+  def init(nil) do
+    opts = [:public, :named_table, {:read_concurrency, true},
+            {:write_concurrency, true}]
+    state = :ets.new(__MODULE__, opts)
+    {:ok, state}
+  end
+
+  def handle_call({:insert, parameters}, {pid, _}, state) do
+    ref = Process.monitor(pid)
+    true = :ets.insert_new(state, {ref, parameters})
+    {:reply, ref, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, _, _}, state) do
+    :ets.delete(state, ref)
+    {:noreply, state}
+  end
 end
 
 defimpl DBConnection.Query, for: Postgrex.Parameters do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -109,6 +109,7 @@ defmodule Postgrex.Protocol do
 
   @spec handle_prepare(Postgrex.Query.t, Keyword.t, state) ::
     {:ok, Postgrex.Query.t, state} |
+    {:error, ArgumentError.t, state} |
     {:error | :disconnect, Postgrex.Query.t, state}
   def handle_prepare(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
@@ -156,7 +157,9 @@ defmodule Postgrex.Protocol do
   end
 
   @spec handle_close(Postgrex.Query.t, Keyword.t, state) ::
-    {:ok, state} | {:error | :disconnect, Postgrex.Error.t, state}
+    {:ok, state} |
+    {:error, ArgumentError.t, state} |
+    {:error | :disconnect, Postgrex.Error.t, state}
   def handle_close(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
   end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -698,7 +698,8 @@ defmodule Postgrex.Protocol do
 
   ## transaction
 
-  defp handle_transaction(name, _, opts, %{postgres: :naive} = s) do
+  defp handle_transaction(name, postgres, opts, %{postgres: :naive} = s)
+  when postgres != :naive do
     handle_transaction(name, :naive, opts, s)
   end
   defp handle_transaction(name, postgres, opts, %{buffer: buffer} = s) do

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -5,18 +5,25 @@ defmodule Postgrex.Protocol do
   alias Postgrex.Query
   import Postgrex.Messages
   import Postgrex.BinaryUtils
+  require Logger
 
   @timeout 5000
   @default_extensions [{Postgrex.Extensions.Binary, nil}, {Postgrex.Extensions.Text, nil}]
   @sock_opts [packet: :raw, mode: :binary, active: false]
 
-  ## TODO: Use struct for state
-  @type state :: %{}
-  @typep parameters :: %{binary => binary}
-  @typep notifications :: [{binary, binary}]
+  defstruct [sock: nil, backend_key: nil, types: nil, timeout: nil,
+             parameters: %{}, buffer: nil]
+
+  @type state :: %__MODULE__{sock: {module, any},
+                             backend_key: {pos_integer, pos_integer},
+                             types: (nil | Postgrex.TypeServer.table),
+                             timeout: timeout,
+                             parameters: %{binary => binary},
+                             buffer: nil | binary | :active_once}
+  @type notify :: ((binary, binary) -> any)
 
   @spec connect(Keyword.t) ::
-    {:ok, state, parameters, notifications} | {:error, Postgrex.Error.t}
+    {:ok, state} | {:error, Postgrex.Error.t}
   def connect(opts) do
     host       = Keyword.fetch!(opts, :hostname) |> to_char_list
     port       = opts[:port] || 5432
@@ -26,108 +33,126 @@ defmodule Postgrex.Protocol do
     extensions = custom ++ @default_extensions
     ssl?       = opts[:ssl] || false
     types?     = opts[:types] || true
-
-    s = %{sock: nil, backend_key: nil, types: nil, timeout: timeout}
+    s = %__MODULE__{timeout: timeout}
 
     types_key = if types?, do: {host, port, Keyword.fetch!(opts, :database), custom}
     status = %{opts: opts, parameters: %{}, notifications: [],
                types_key: types_key, types_ref: nil, extensions: extensions,
                extension_info: nil}
     case connect(host, port, sock_opts ++ @sock_opts, s) do
-      {:ok, s} when ssl?  -> ssl(s, status)
-      {:ok, s}            -> startup(s, status)
+      {:ok, s} when ssl?  -> s |> ssl(status) |> connected()
+      {:ok, s}            -> s |> startup(status) |> connected()
       {:error, _} = error -> error
     end
   end
 
-  @spec checkout(state, binary | :active_once) ::
-    {:ok, binary} | {:error, Postgrex.Error.t}
-  def checkout(%{sock: sock} = s, :active_once) do
-    case setopts(sock, [active: :false]) do
-      :ok               -> recv_buffer(s)
-      {:error, _} = err -> err
-    end
-  end
-  def checkout(_, buffer), do: {:ok, buffer}
-
-  @spec checkin(state, binary) :: :ok | {:error, Postgrex.Error.t}
-  def checkin(%{sock: sock}, buffer) do
-    activate(sock, buffer)
+  defp connected({:ok, _} = ok), do: ok
+  defp connected({:error, _} = err), do: err
+  defp connected({:disconnect, err, s}) do
+    disconnect(s)
+    {:error, err}
   end
 
-  @spec simple_query(state, String.t, binary | :active_once) ::
-    {:ok, Postgrex.Result.t | Postgrex.Error.t, parameters, notifications,
-      binary} |
-    {:error, Postgrex.Error.t}
-  def simple_query(s, statement, buffer) do
-    status = %{parameters: %{}, notifications: [], ok: :result, sync: :sync}
-    simple_send(s, status, statement, buffer)
+  def disconnect(s) do
+    sock_close(s)
+    _ = recv_buffer(s)
+    :ok
   end
 
-  @spec query(state, String.t, [any], binary | :active_once) ::
-    {:ok, Postgrex.Result.t | Postgrex.Error.t |
-      {:error | :throw | :exit, any, list}, parameters, notifications, binary} |
-    {:error, Postgrex.Error.t}
-  def query(s, statement, params, buffer) do
-    status = %{parameters: %{}, notifications: [], ok: :status,
-               sync: :close_sync}
-    case prepare_send(s, status, "", statement, buffer) do
-      {:ok, %Query{} = query, status, buffer} ->
-        query_encode(s, %{status | ok: :result}, query, params, buffer)
-      {:ok, result, status, buffer} ->
-        ok(result, %{status | ok: :result}, buffer)
-      result ->
-        result
+  @spec checkout(state) ::
+    {:ok, state} | {:disconnect, Postgrex.Error.t, state}
+  def checkout(%{buffer: :active_once} = s) do
+    case setopts(s, [active: :false], :active_once) do
+      :ok                       -> recv_buffer(s)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
-  @spec prepare(state, iodata, iodata, binary | :active_once) ::
-    {:ok, Postgrex.Query.t | Postgrex.Error.t |
-      {:error | :throw | :exit, any, list}, parameters, notifications, binary} |
-    {:error, Postgrex.Error.t}
-  def prepare(s, name, statement, buffer) do
-    status = %{parameters: %{}, notifications: [], ok: :result}
-    prepare_send(s, status, name, statement, buffer)
+  @spec checkin(state) ::
+  {:ok, state} | {:disconnect, Postgrex.Error.t, state}
+  def checkin(%{buffer: buffer} = s) when is_binary(buffer) do
+    activate(s, buffer)
   end
 
-  @spec execute(state, Postgrex.Query.t, binary | :active_once) ::
-    {:ok, Postgrex.Result.t | Postgrex.Error.t |
-      {:error | :throw | :exit, any, list}, parameters, notifications, binary} |
-    {:error, Postgrex.Error.t}
-  def execute(s, %Query{encoders: nil} = query, buffer) do
-    status = %{parameters: %{}, notifications: [], ok: :result, sync: :sync}
-    execute_send(s, status, query, buffer)
+  @spec handle_prepare(Postgrex.Query.t, Keyword.t, state) ::
+    {:ok, Postgrex.Query.t, state} |
+    {:error | :disconnect, Postgrex.Query.t, state}
+  def handle_prepare(query, opts, s) do
+    case query do
+      %Query{param_formats: pfs, encoders: encoders} when is_list(pfs) and is_list(encoders) ->
+        handle_prepare(query, :parse, opts, s)
+      _ ->
+        handle_prepare(query, :parse_describe, opts, s)
+    end
   end
 
-  @spec close(state, Postgrex.Query.t, binary | :active_once) ::
-    {:ok, parameters, notifications, binary} | {:error, Postgrex.Error.t}
-  def close(s, query, buffer) do
-    status = %{parameters: %{}, notifications: [], ok: :no_result}
-    close(s, status, query, nil, buffer)
+  @spec handle_execute(Postgrex.Query.t, Keyword.t, state) ::
+    {:ok, Postgrex.Result.t, state} |
+    {:error, ArgumentError.t, state} |
+    {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_execute(%Query{encoders: nil} = query, opts, s) do
+    handle_execute(query, :sync, opts, s)
+  end
+  @spec handle_execute(Postgrex.Parameters.t, Keyword.t, state) ::
+    {:ok, %{binary => binary}, state}
+  def handle_execute(%Postgrex.Parameters{} = res, _, s) do
+    {:ok, %Postgrex.Parameters{res | parameters: s.parameters}, s}
   end
 
-  @spec message(state, any) ::
-    {:ok, parameters, notifications} | {:error, Postgrex.Error.t} | :unknown
-  def message(%{sock: {:gen_tcp, sock}} = s, {:tcp, sock, data}) do
-    data(s, data)
+  @spec handle_execute_close(Postgrex.Query.t, Keyword.t, state) ::
+    {:ok, Postgrex.Result.t, state} |
+    {:error, ArgumentError.t, state} |
+    {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_execute_close(query, opts, s) do
+    handle_execute(query, :close_sync, opts, s)
   end
-  def message(%{sock: {:gen_tcp, sock}}, {:tcp_closed, sock}) do
-    {:error, Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: :closed)}
+
+  @spec handle_close(Postgrex.Query.t, Keyword.t, state) ::
+    {:ok, state} | {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_close(query, opts, %{buffer: buffer} = s) do
+    status = %{notify: notify(opts)}
+    close(%{s | buffer: nil}, status, query, nil, buffer)
   end
-  def message(%{sock: {:gen_tcp, sock}}, {:tcp_error, sock, reason}) do
-    {:error, Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: reason)}
+
+  @spec handle_simple(String.t, Keyword.t, state) ::
+    {:ok, Postgrex.Result.t, state} |
+    {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_simple(statement, opts, %{buffer: buffer} = s) do
+    status = %{notify: notify(opts), sync: :sync}
+    simple_send(%{s | buffer: nil}, status, statement, buffer)
   end
-  def message(%{sock: {:ssl, sock}} = s, {:ssl, sock, data}) do
-    data(s, data)
+
+  @spec handle_info(any, Keyword.t, state) ::
+    {:ok, state} | {:error | :disconnect, Postgrex.Error.t}
+  def handle_info(msg, opts \\ [], s)
+
+  def handle_info({:tcp, sock, data}, opts, %{sock: {:gen_tcp, sock}} = s) do
+    handle_data(s, opts, data)
   end
-  def message(%{sock: {:ssl, sock}}, {:ssl_closed, sock}) do
-    {:error, Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: :closed)}
+  def handle_info({:tcp_closed, sock}, _, %{sock: {:gen_tcp, sock}} = s) do
+    err = Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: :closed)
+    {:disconnect, err, s}
   end
-  def message(%{sock: {:ssl, sock}}, {:ssl_error, sock, reason}) do
-    {:error, Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: reason)}
+  def handle_info({:tcp_error, sock, reason}, _, %{sock: {:gen_tcp, sock}} = s) do
+    err = Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: reason)
+    {:disconnect, err, s}
   end
-  def message(_, _) do
-    :unknown
+  def handle_info({:ssl, sock, data}, opts, %{sock: {:ssl, sock}} = s) do
+    handle_data(s, opts, data)
+  end
+  def handle_info({:ssl_closed, sock}, _, %{sock: {:ssl, sock}} = s) do
+    err = Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: :closed)
+    {:disconnect, err, s}
+  end
+  def handle_info({:ssl_error, sock, reason}, _, %{sock: {:ssl, sock}} = s) do
+    err = Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: reason)
+    {:disconnect, err, s}
+  end
+  def handle_info(msg, _, s) do
+    Logger.info(fn() -> [inspect(__MODULE__), ?\s, inspect(self()),
+      " received unexpected message: " | inspect(msg)]
+    end)
+    {:ok, s}
   end
 
   ## connect
@@ -154,8 +179,8 @@ defmodule Postgrex.Protocol do
 
   ## ssl
 
-  defp ssl(%{sock: sock} = s, status) do
-    case msg_send(msg_ssl_request(), sock) do
+  defp ssl(s, status) do
+    case msg_send(s, msg_ssl_request(), "") do
       :ok              -> ssl_recv(s, status)
       {:error, _} = err -> err
     end
@@ -166,9 +191,10 @@ defmodule Postgrex.Protocol do
       {:ok, <<?S>>} ->
         ssl_connect(s, status)
       {:ok, <<?N>>} ->
-        {:error, %Postgrex.Error{message: "ssl not available"}}
+        disconnect(s, %Postgrex.Error{message: "ssl not available"}, "")
       {:error, reason} ->
-        {:error, Postgrex.Error.exception(tag: :tcp, action: "recv", reason: reason)}
+        err = Postgrex.Error.exception(tag: :tcp, action: "recv", reason: reason)
+        disconnect(s, err, "")
     end
   end
 
@@ -177,37 +203,38 @@ defmodule Postgrex.Protocol do
       {:ok, ssl_sock} ->
         startup(%{s | sock: {:ssl, ssl_sock}}, status)
       {:error, reason} ->
-        {:error, Postgrex.Error.exception(tag: :ssl, action: "connect", reason: reason)}
+        err = Postgrex.Error.exception(tag: :ssl, action: "connect", reason: reason)
+        disconnect(s, err, "")
     end
   end
 
   ## startup
 
-  defp startup(%{sock: sock} = s, %{opts: opts} = status) do
+  defp startup(s, %{opts: opts} = status) do
     params = opts[:parameters] || []
     user = Keyword.fetch!(opts, :username)
     database = Keyword.fetch!(opts, :database)
     msg = msg_startup(params: [user: user, database: database] ++ params)
-    case msg_send(msg, sock) do
-      :ok               -> auth_recv(s, status, <<>>)
-      {:error, _} = err -> err
+    case msg_send(s, msg, "") do
+      :ok                       -> auth_recv(s, status, <<>>)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
   ## auth
 
-  defp auth_recv(%{sock: sock, timeout: timeout} = s, status, buffer) do
-    case msg_recv(sock, buffer, timeout) do
+  defp auth_recv(s, status, buffer) do
+    case msg_recv(s, buffer) do
       {:ok, msg_auth(type: :ok), buffer} ->
         init_recv(s, status, buffer)
       {:ok, msg_auth(type: :cleartext), buffer} ->
         auth_cleartext(s, status, buffer)
       {:ok, msg_auth(type: :md5, data: salt), buffer} ->
         auth_md5(s, status, salt, buffer)
-      {:ok, msg_error(fields: fields), _} ->
-        {:error, Postgrex.Error.exception(postgres: fields)}
-      {:error, _} = err->
-        err
+      {:ok, msg_error(fields: fields), buffer} ->
+        disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
@@ -227,47 +254,47 @@ defmodule Postgrex.Protocol do
     auth_send(s, msg_password(pass: ["md5", digest]), status, buffer)
   end
 
-  defp auth_send(%{sock: sock} = s, msg, status, buffer) do
-    case msg_send(msg, sock) do
-      :ok               -> auth_recv(s, status, buffer)
-      {:error, _} = err -> err
+  defp auth_send(s, msg, status, buffer) do
+    case msg_send(s, msg, buffer) do
+      :ok                       -> auth_recv(s, status, buffer)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
   ## init
 
-  defp init_recv(%{sock: sock, timeout: timeout} = s, status, buffer) do
-    case msg_recv(sock, buffer, timeout) do
+  defp init_recv(s, status, buffer) do
+    case msg_recv(s, buffer) do
       {:ok, msg_backend_key(pid: pid, key: key), buffer} ->
         init_recv(%{s | backend_key: {pid, key}}, status, buffer)
       {:ok, msg_ready(), buffer} ->
         bootstrap(s, status, buffer)
-      {:ok, msg_error(fields: fields), _} ->
-        {:error, Postgrex.Error.exception(postgres: fields)}
+      {:ok, msg_error(fields: fields), buffer} ->
+        disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        init_recv(s, handle_msg(status, msg), buffer)
-      {:error, _} = err ->
-        err
+        init_recv(handle_msg(s, status, msg), status, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   ## bootstrap
 
-  defp bootstrap(s, %{types_key: nil} = status, buffer) do
-    bootstrap_ready(s, status, buffer)
+  defp bootstrap(s, %{types_key: nil}, buffer) do
+    activate(s, buffer)
   end
   defp bootstrap(s, %{types_key: types_key} = status, buffer) do
     case Postgrex.TypeServer.fetch(types_key) do
       {:ok, table} ->
-        bootstrap_ready(%{s | types: table}, status, buffer)
+        activate(%{s | types: table}, buffer)
       {:lock, ref, table} ->
         status = %{status | types_ref: ref}
         bootstrap_send(%{s | types: table}, status, buffer)
     end
   end
 
-  defp bootstrap_send(%{sock: sock} = s, status, buffer) do
-    %{parameters: parameters, extensions: extensions} = status
+  defp bootstrap_send(%{parameters: parameters} = s, status, buffer) do
+    %{extensions: extensions} = status
 
     extension_keys = Enum.map(extensions, &elem(&1, 0))
     extension_opts = Types.prepare_extensions(extensions, parameters)
@@ -275,42 +302,40 @@ defmodule Postgrex.Protocol do
     version = parameters["server_version"] |> Postgrex.Utils.parse_version
     statement = Types.bootstrap_query(matchers, version)
     msg = msg_query(statement: statement)
-    case msg_send(msg, sock) do
+    case msg_send(s, msg, buffer) do
       :ok ->
         status = %{status | extension_info: {extension_keys, extension_opts}}
         bootstrap_recv(s, status, buffer)
-      {:error, } = err ->
-        err
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   defp bootstrap_recv(s, status, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_row_desc(), buffer} ->
         bootstrap_recv(s, status, [], buffer)
-      {:ok, msg_error(fields: fields), _} ->
-        {:error, Postgrex.Error.exception(postgres: fields)}
+      {:ok, msg_error(fields: fields), buffer} ->
+        disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        bootstrap_recv(s, handle_msg(status, msg), buffer)
-      {:error, _} = err ->
-        err
+        bootstrap_recv(handle_msg(s, status, msg), status, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   defp bootstrap_recv(s, status, rows, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_data_row(values: values), buffer} ->
         bootstrap_recv(s, status, [values | rows], buffer)
       {:ok, msg_command_complete(), buffer} ->
         bootstrap_types(s, status, rows, buffer)
-      {:ok, msg_error(fields: fields), _} ->
-        {:error, Postgrex.Error.exception(postgres: fields)}
+      {:ok, msg_error(fields: fields), buffer} ->
+        disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        bootstrap_recv(s, handle_msg(status, msg), rows, buffer)
-      {:error, _} = err ->
-        err
+        bootstrap_recv(handle_msg(s, status, msg), status, rows, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
@@ -323,161 +348,133 @@ defmodule Postgrex.Protocol do
   end
 
   defp bootstrap_sync_recv(s, status, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_ready(), buffer} ->
-        bootstrap_ready(s, status, buffer)
+        activate(s, buffer)
       {:ok, msg, buffer} ->
-        bootstrap_sync_recv(s, handle_msg(status, msg), buffer)
-      {:error, _} = err ->
-        err
-    end
-  end
-
-  defp bootstrap_ready(%{sock: sock} = s, status, buffer) do
-    %{parameters: parameters, notifications: notifications} = status
-    case activate(sock, buffer) do
-      :ok ->
-        {:ok, s, parameters, Enum.reverse(notifications)}
-      {:error, _} = err ->
-        err
+        bootstrap_sync_recv(handle_msg(s, status, msg), status, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   ## simple
 
-  defp simple_send(%{sock: sock} = s, status, statement, buffer) do
+  defp simple_send(s, status, statement, buffer) do
     msg = msg_query(statement: statement)
-    case msg_send(msg, sock) do
-      :ok               -> simple_recv(s, status, buffer)
-      {:error, _} = err -> err
+    case msg_send(s, msg, buffer) do
+      :ok                       -> simple_recv(s, status, buffer)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
   defp simple_recv(s, status, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_command_complete(tag: tag), buffer} ->
         complete(s, status, %Query{}, [], tag, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        simple_recv(s, handle_msg(status, msg), buffer)
-      {:error, _} = err ->
-        err
-    end
-  end
-
-  ## query
-
-  defp query_encode(s, status, query, params, buffer) do
-    try do
-      Query.encode(%Query{query | params: params})
-    catch
-      kind, reason ->
-        close(s, status, query, {kind, reason, System.stacktrace}, buffer)
-    else
-      query ->
-        execute_send(s, status, query, buffer)
+        simple_recv(handle_msg(s, status, msg), status, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   ## prepare
 
-  defp prepare_send(s, status, name, statement, buffer) do
-    msgs = [
-      msg_parse(name: name, statement: statement, type_oids: []),
-      msg_describe(type: :statement, name: name),
-      msg_flush() ]
-    case msg_send(msgs, s) do
+  defp handle_prepare(query, prepare, opts, %{buffer: buffer} = s) do
+    status = %{notify: notify(opts), prepare: prepare}
+    prepare_send(%{s | buffer: nil}, status, query, buffer)
+  end
+
+  defp prepare_send(s, %{prepare: prepare} = status, query, buffer) do
+    %Query{name: name, statement: statement} = query
+    msgs =
+     case prepare do
+       :parse_describe ->
+          [msg_describe(type: :statement, name: name), msg_flush()]
+       :parse ->
+          [msg_flush()]
+      end
+    msgs = [msg_parse(name: name, statement: statement, type_oids: []) | msgs]
+    case msg_send(s, msgs, buffer) do
       :ok ->
-        parse_recv(s, status, %Query{name: name, statement: statement}, buffer)
-      {:error, _} = err -> err
+        parse_recv(s, status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
-  defp parse_recv(s, status, query, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
-      {:ok, msg_parse_complete(), buffer} ->
-        describe_recv(s, status, query, buffer)
+  defp parse_recv(s, %{prepare: prepare} = status, query, buffer) do
+    case msg_recv(s, buffer) do
+      {:ok, msg_parse_complete(), buffer} when prepare == :parse_describe ->
+        describe_recv(s, status, %Query{query | types: s.types}, buffer)
+      {:ok, msg_parse_complete(), buffer} when prepare == :parse ->
+        ok(s, query, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         exception = Postgrex.Error.exception(postgres: fields)
-        sync_close(s, status, query, exception, buffer)
+        close_sync(s, status, query, exception, buffer)
       {:ok, msg, buffer} ->
-        parse_recv(s, handle_msg(status, msg), query, buffer)
-      {:error, _} = err ->
-        err
+        parse_recv(handle_msg(s, status, msg), status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   defp describe_recv(s, status, query, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_no_data(), buffer} ->
-        ok(query, status, buffer)
-      {:ok, msg_parameter_desc(type_oids: []), buffer} ->
-        describe_recv(s, status, query, buffer)
+        ok(s, query, buffer)
       {:ok, msg_parameter_desc(type_oids: param_oids), buffer} ->
-        describe_params(s, status, query, param_oids, buffer)
+        describe_recv(s, status, %Query{query | encoders: param_oids}, buffer)
       {:ok, msg_row_desc(fields: fields), buffer} ->
-        describe_results(s, status, query, fields, buffer)
+        {col_oids, col_names} = columns(fields)
+        query = %Query{query | columns: col_names, decoders: col_oids}
+        ok(s, query, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         exception = Postgrex.Error.exception(postgres: fields)
-        sync_close(s, status, query, exception, buffer)
+        close_sync(s, status, query, exception, buffer)
       {:ok, msg, buffer} ->
-        describe_recv(s, handle_msg(status, msg), query, buffer)
-      {:error, _} = err ->
-        err
+        describe_recv(handle_msg(s, status, msg), status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
-  defp describe_params(s, status, query, param_oids, buffer) do
-    try do
-      encoders(param_oids, s.types)
-    catch
-      kind, reason ->
-        close(s, status, query, {kind, reason, System.stacktrace}, buffer)
-    else
-      {pfs, encoders} ->
-        query = %Query{query | param_formats: pfs, encoders: encoders}
-        describe_recv(s, status, query, buffer)
-    end
-  end
-
-  defp describe_results(s, status, query, fields, buffer) do
-    {col_oids, col_names} = columns(fields)
-    try do
-      decoders(col_oids, s.types)
-    catch
-      kind, reason ->
-        close(s, status, query, {kind, reason, System.stacktrace}, buffer)
-    else
-      {rfs, decoders} ->
-        query = %Query{query | result_formats: rfs, decoders: decoders,
-          columns: col_names}
-        ok(query, status, buffer)
-    end
-  end
-
-  defp sync_close(s, status, %Query{name: name}, result, buffer) do
+  defp close_sync(s, status, %Query{name: name}, result, buffer) do
     msgs = [
       msg_close(type: :statement, name: name),
       msg_sync() ]
-    case msg_send(msgs, s) do
-      :ok               -> sync_recv(s, status, result, buffer)
-      {:error, _} = err -> err
+    case msg_send(s, msgs, buffer) do
+      :ok                       -> sync_recv(s, status, result, buffer)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
   ## execute
 
+  defp handle_execute(query, sync, opts, %{buffer: buffer} = s) do
+    case query do
+      %Query{param_formats: nil, types: nil} ->
+        query_error(s, "query #{inspect query} has not been prepared")
+      %Query{param_formats: nil} ->
+        query_error(s, "query #{inspect query} has not been described")
+      %Query{encoders: encoders} when is_list(encoders) ->
+        query_error(s, "query #{inspect query} has not been encoded")
+      %Query{} = query ->
+       status = %{notify: notify(opts), sync: sync}
+       execute_send(%{s | buffer: nil}, status, query, buffer)
+    end
+  end
+
+  defp query_error(s, msg) do
+    {:error, ArgumentError.exception(msg), s}
+  end
+
   defp execute_send(s, %{sync: sync} = status, query, buffer) do
     %Query{param_formats: pfs, params: params, result_formats: rfs,
            name: name} = query
-    pfs = pfs || []
-    params = params || []
-    rfs = rfs || []
     msgs =
       case sync do
         :close_sync -> [msg_close(type: :statement, name: name), msg_sync()]
@@ -487,29 +484,27 @@ defmodule Postgrex.Protocol do
       msg_bind(name_port: "", name_stat: name, param_formats: pfs, params: params, result_formats: rfs),
       msg_execute(name_port: "", max_rows: 0) |
       msgs ]
-    case msg_send(msgs, s) do
-      :ok               -> bind_recv(s, status, query, buffer)
-      {:error, _} = err -> err
+    case msg_send(s, msgs, buffer) do
+      :ok                       -> bind_recv(s, status, query, buffer)
+      {:disconnect, _, _} = dis -> dis
     end
   end
 
   defp bind_recv(s, status, query, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_bind_complete(), buffer} ->
         execute_recv(s, status, query, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        bind_recv(s, handle_msg(status, msg), query, buffer)
-      {:error, _} = err ->
-        err
+        bind_recv(handle_msg(s, status, msg), status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   defp execute_recv(s, status, query, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_data_row(values: values), buffer} ->
         execute_recv(s, status, query, [values], buffer)
       {:ok, msg_command_complete(tag: tag), buffer} ->
@@ -519,23 +514,22 @@ defmodule Postgrex.Protocol do
       {:ok, msg_error(fields: fields), buffer} ->
         sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        execute_recv(s, handle_msg(status, msg), query, buffer)
-      {:error, _} = err ->
-        err
+        execute_recv(handle_msg(s, status, msg), status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   defp execute_recv(s, status, query, rows, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+     case msg_recv(s, buffer) do
       {:ok, msg_data_row(values: values), buffer} ->
         execute_recv(s, status, query, [values | rows], buffer)
       {:ok, msg_command_complete(tag: tag), buffer} ->
         complete(s, status, query, rows, tag, buffer)
       {:ok, msg, buffer} ->
-        execute_recv(s, handle_msg(status, msg), query, buffer)
-      {:error, _} = err ->
-        err
+        execute_recv(handle_msg(s, status, msg), status, query, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
@@ -563,21 +557,20 @@ defmodule Postgrex.Protocol do
     msgs = [
       msg_close(type: :statement, name: name),
       msg_flush() ]
-    case msg_send(msgs, s) do
+    case msg_send(s, msgs, buffer) do
       :ok               -> close_recv(s, status, result, buffer)
       {:error, _} = err -> err
     end
   end
 
   defp close_recv(s, status, result, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_close_complete(), buffer} ->
-        ok(result, status, buffer)
+        ok(s, result, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
-        ok(Postgrex.Error.exception(postgres: fields), status, buffer)
+        ok(s, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
-        close_recv(s, handle_msg(status, msg), result, buffer)
+        close_recv(handle_msg(s, status, msg), status, result, buffer)
       {:error, _} = err ->
         err
     end
@@ -585,48 +578,33 @@ defmodule Postgrex.Protocol do
 
   ## data
 
-  defp data(s, status \\ %{parameters: %{}, notifications: []}, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
-      {:ok, msg_error(fields: fields), _} ->
-        {:error, Postgrex.Error.exception(postgres: fields)}
-      {:ok, msg, <<>>} ->
-        data_ready(s, handle_msg(status, msg))
-      {:ok, msg, buffer} ->
-        data(s, handle_msg(status, msg), buffer)
-      {:error, _} = err ->
-        err
-    end
+  defp handle_data(s, opts, buffer) do
+    data(s, %{notify: notify(opts)}, buffer)
   end
 
-  defp data_ready(%{sock: sock}, status) do
-    case activate(sock, <<>>) do
-      :ok ->
-        %{parameters: parameters, notifications: notifications} = status
-        {:ok, parameters, Enum.reverse(notifications)}
-      {:error, _} = err ->
-        err
+  defp data(s, status, buffer) do
+    case msg_recv(s, buffer) do
+      {:ok, msg_error(fields: fields), buffer} ->
+        disconnect(s, Postgrex.Error.exception(postgres: fields), buffer)
+      {:ok, msg, <<>>} ->
+        activate(handle_msg(s, status, msg), <<>>)
+      {:ok, msg, buffer} ->
+        data(handle_msg(s, status, msg), status, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
   ## helpers
 
-  defp encoders(oids, types) do
-    oids
-    |> Enum.map(&Types.encoder(&1, types))
-    |> :lists.unzip()
+  defp notify(opts) do
+    opts[:notify] || fn(_, _) -> :ok end
   end
 
   defp columns(fields) do
     Enum.map(fields, fn row_field(type_oid: oid, name: name) ->
       {oid, name}
     end) |> :lists.unzip
-  end
-
-  defp decoders(oids, types) do
-    oids
-    |> Enum.map(&Types.decoder(&1, types))
-    |> :lists.unzip()
   end
 
   defp tag(:gen_tcp), do: :tcp
@@ -646,45 +624,45 @@ defmodule Postgrex.Protocol do
     {command, List.last(nums)}
   end
 
-  defp msg_recv({:gen_tcp, sock}, :active_once, timeout) do
+  defp msg_recv(%{sock: {:gen_tcp, sock}, timeout: timeout} = s, :active_once) do
     receive do
       {:tcp, ^sock, buffer} ->
-        msg_recv(sock, buffer, timeout)
+        msg_recv(s, buffer)
       {:tcp_closed, ^sock} ->
-        {:error, :closed}
+        disconnect(s, :tcp, "async_recv", :closed, :active_once)
       {:tcp_error, ^sock, reason} ->
-        {:error, reason}
+        disconnect(s, :tcp, "async_recv", reason, :active_once)
     after
       timeout ->
-        {:error, timeout}
+        disconnect(s, :tcp, "async_recv", :timeout, :active_one)
     end
   end
-  defp msg_recv({:ssl, sock}, :active_once, timeout) do
+  defp msg_recv(%{sock: {:ssl, sock}, timeout: timeout} = s, :active_once) do
     receive do
       {:ssl, ^sock, buffer} ->
-        msg_recv(sock, buffer, timeout)
+        msg_recv(s, buffer)
       {:ssl_closed, ^sock} ->
-        {:error, :closed}
+        disconnect(s, :ssl, "async_recv", :closed, :active_once)
       {:ssl_error, ^sock, reason} ->
-        {:error, reason}
+        disconnect(s, :ssl, "async_recv", reason, :active_once)
     after
       timeout ->
-        {:error, timeout}
+        disconnect(s, :ssl, "async_recv", :timeout, :active_once)
     end
   end
-  defp msg_recv(sock, buffer, timeout) do
+  defp msg_recv(s, buffer) do
     case msg_decode(buffer) do
       {:ok, _, _} = ok -> ok
-      {:more, more}    -> msg_recv(sock, buffer, more, timeout)
+      {:more, more}    -> msg_recv(s, buffer, more)
     end
   end
 
-  defp msg_recv({mod, sock} = sock_info, buffer, more, timeout) do
+  defp msg_recv(%{sock: {mod, sock}, timeout: timeout} = s, buffer, more) do
     case mod.recv(sock, more, timeout) do
       {:ok, data} ->
-        msg_recv(sock_info, buffer <> data, timeout)
+        msg_recv(s, buffer <> data)
       {:error, reason} ->
-        {:error, Postgrex.Error.exception(tag: tag(mod), action: "recv", reason: reason)}
+        disconnect(s, tag(mod), "recv", reason, buffer)
     end
   end
 
@@ -701,109 +679,123 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp msg_send(msg, %{sock: sock}), do: msg_send(msg, sock)
-
-  defp msg_send(msgs, sock) when is_list(msgs) do
+  defp msg_send(s, msgs, buffer) when is_list(msgs) do
     binaries = Enum.reduce(msgs, [], &[&2 | encode_msg(&1)])
-    do_send(sock, binaries)
+    do_send(s, binaries, buffer)
   end
 
-  defp msg_send(msg, sock) do
-    do_send(sock, encode_msg(msg))
+  defp msg_send(s, msg, buffer) do
+    do_send(s, encode_msg(msg), buffer)
   end
 
-  defp do_send({mod, sock}, data) do
+  defp do_send(%{sock: {mod, sock}} = s, data, buffer) do
     case mod.send(sock, data) do
       :ok ->
         :ok
       {:error, reason} ->
-        {:error, Postgrex.Error.exception(tag: tag(mod), action: "send", reason: reason)}
+        disconnect(s, tag(mod), "send", reason, buffer)
     end
   end
 
   ## TODO: See if :binary.copy/1 of parameters/notifications reduces memory
-  defp handle_msg(status, msg_parameter(name: name, value: value)) do
-    update_in(status.parameters, &Map.put(&1, name, value))
+  defp handle_msg(s, _, msg_parameter(name: name, value: value)) do
+    update_in(s.parameters, &Map.put(&1, name, value))
   end
-  defp handle_msg(status, msg_notify(channel: channel, payload: payload)) do
-    update_in(status.notifications, &[{channel, payload} | &1])
+  defp handle_msg(s, status, msg_notify(channel: channel, payload: payload)) do
+    %{notify: notify} = status
+    notify.(channel, payload)
+    s
   end
-  defp handle_msg(status, msg_notice()) do
+  defp handle_msg(s, _, msg_notice()) do
     # TODO: subscribers
-    status
+    s
   end
 
-  defp ok(result, %{ok: :status} = status, buffer) do
-    {:ok, result, status, buffer}
+  defp ok(s, %Postgrex.Result{} = res, buffer) do
+    {:ok, res, %{s | buffer: buffer}}
   end
-  defp ok(result, %{ok: :result} = status, buffer) do
-    %{parameters: parameters, notifications: notifications} = status
-    {:ok, result, parameters, Enum.reverse(notifications), buffer}
+  defp ok(s, %Postgrex.Query{} = query, buffer) do
+    {:ok, query, %{s | buffer: buffer}}
+   end
+  defp ok(s, nil, buffer) do
+    {:ok, %{s | buffer: buffer}}
   end
-  defp ok(nil, %{ok: :no_result} = status, buffer) do
-    %{parameters: parameters, notifications: notifications} = status
-    {:ok, parameters, Enum.reverse(notifications), buffer}
+  defp ok(s, %Postgrex.Error{} = err, buffer) do
+    {:error, err, %{s | buffer: buffer}}
+  end
+
+  defp disconnect(s, tag, action, reason, buffer) do
+    err = Postgrex.Error.exception(tag: tag, action: action, reason: reason)
+    disconnect(s, err, buffer)
+  end
+
+  defp disconnect(s, err, buffer) do
+    {:disconnect, err, %{s | buffer: buffer}}
   end
 
   defp sync_recv(s, status, result, buffer) do
-    %{sock: sock, timeout: timeout} = s
-    case msg_recv(sock, buffer, timeout) do
+    case msg_recv(s, buffer) do
       {:ok, msg_ready(), buffer} ->
-        ok(result, status, buffer)
+        ok(s, result, buffer)
       {:ok, msg_close_complete(), buffer} ->
         sync_recv(s, status, result, buffer)
       {:ok, msg, buffer} ->
-        sync_recv(s, handle_msg(status, msg), result, buffer)
-      {:error, _} = err ->
-        err
+        sync_recv(handle_msg(s, status, msg), status, result, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
     end
   end
 
-  defp recv_buffer(%{sock: {:gen_tcp, sock}}) do
+  defp recv_buffer(%{sock: {:gen_tcp, sock}} = s) do
     receive do
       {:tcp, ^sock, buffer} ->
-        {:ok, buffer}
+        {:ok, %{s | buffer: buffer}}
       {:tcp_closed, ^sock} ->
-        {:error, Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: :closed)}
+        disconnect(s, :tcp, "async recv", :closed, "")
       {:tcp_error, ^sock, reason} ->
-        {:error, Postgrex.Error.exception(tag: :tcp, action: "async recv", reason: reason)}
+        disconnect(s, :tcp, "async_recv", reason, "")
     after
       0 ->
-        {:ok, <<>>}
+        {:ok, %{s | buffer: <<>>}}
     end
   end
-  defp recv_buffer(%{sock: {:ssl, sock}}) do
+  defp recv_buffer(%{sock: {:ssl, sock}} = s) do
     receive do
       {:ssl, ^sock, buffer} ->
-        {:ok, buffer}
+        {:ok, %{s | buffer: buffer}}
       {:ssl_closed, ^sock} ->
-        {:error, Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: :closed)}
+        disconnect(s, :ssl, "async recv", :closed, "")
       {:ssl_error, ^sock, reason} ->
-        {:error, Postgrex.Error.exception(tag: :ssl, action: "async recv", reason: reason)}
+        disconnect(s, :ssl, "async recv", reason, "")
     after
       0 ->
-        {:ok, <<>>}
+        {:ok, %{s | buffer: <<>>}}
     end
   end
 
   ## Fake [active: once] if buffer not empty
-  defp activate(sock, <<>>) do
-    setopts(sock, [active: :once])
+  defp activate(s, <<>>) do
+    case setopts(s, [active: :once], <<>>) do
+      :ok  -> {:ok, %{s | buffer: :active_once}}
+      other -> other
+    end
   end
-  defp activate({mod, sock}, buffer) do
+  defp activate(%{sock: {mod, sock}} = s, buffer) do
     _ = send(self(), {tag(mod), sock, buffer})
-    :ok
+    {:ok, s}
   end
 
-  defp setopts({mod, sock}, opts) do
+  defp setopts(%{sock: {mod, sock}} = s, opts, buffer) do
     case setopts(mod, sock, opts) do
       :ok ->
         :ok
       {:error, reason} ->
-        {:error, Postgrex.Error.exception(tag: tag(mod), action: "setopts", reason: reason)}
+        disconnect(s, tag(mod), "setopts", reason, buffer)
     end
   end
 
   defp setopts(:gen_tcp, sock, opts), do: :inet.setopts(sock, opts)
   defp setopts(:ssl, sock, opts), do: :ssl.setopts(sock, opts)
+
+  defp sock_close(%{sock: {mod, sock}}), do: mod.close(sock)
 end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -651,14 +651,13 @@ defmodule Postgrex.Protocol do
   end
   defp complete(s, status, query, rows, tag, buffer) do
     {command, nrows} = decode_tag(tag)
-    %Query{decoders: decoders, columns: cols} = query
+    %Query{columns: cols} = query
     # Fix for PostgreSQL 8.4 (doesn't include number of selected rows in tag)
     if is_nil(nrows) and command == :select do
       nrows = length(rows)
     end
     result = %Postgrex.Result{command: command, num_rows: nrows || 0,
-                              rows: rows, columns: cols,
-                              decoders: decoders}
+                              rows: rows, columns: cols}
     sync_recv(s, status, result, buffer)
   end
 

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -97,7 +97,9 @@ defimpl DBConnection.Query, for: Postgrex.Query do
 
   def decode(_, result, opts) do
     case opts[:decode] || :auto do
-      :auto   -> Postgrex.Result.decode(result)
+      :auto   ->
+        mapper = opts[:decode_mapper] || fn x -> x end
+        Postgrex.Result.decode(result, mapper)
       :manual -> result
     end
   end

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -36,7 +36,7 @@ defmodule Postgrex.Query do
   @spec encode(t, [any], (term -> term)) :: [any]
   def encode(query, params, mapper \\ fn x -> x end)
 
-  def encode(%Postgrex.Query{param_formats: nil, types: nil} = query, _params, _mapper) do
+  def encode(%Postgrex.Query{types: nil} = query, _params, _mapper) do
     raise ArgumentError, "query #{inspect query} has not been prepared"
   end
 
@@ -85,8 +85,7 @@ defimpl DBConnection.Query, for: Postgrex.Query do
     {pfs, encoders} = encoders(poids, types)
     {rfs, decoders} = decoders(roids, types)
     %Postgrex.Query{query | param_formats: pfs, encoders: encoders,
-                            result_formats: rfs, decoders: decoders,
-                            types: nil}
+                            result_formats: rfs, decoders: decoders}
   end
 
   def encode(query, params, opts) do

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -119,3 +119,9 @@ defimpl DBConnection.Query, for: Postgrex.Query do
     |> :lists.unzip()
   end
 end
+
+defimpl String.Chars, for: Postgrex.Query do
+  def to_string(%Postgrex.Query{statement: statement}) do
+    IO.iodata_to_binary(statement)
+  end
+end

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -10,6 +10,7 @@ defmodule Postgrex.Query do
     * `columns` - The column names;
     * `result_formats` - List of formats for each column is decoded from;
     * `decoders` - List of anonymous functions to decode each column;
+    * `types` - The type serber table to fetch the type information from;
   """
 
   import Postgrex.BinaryUtils
@@ -19,13 +20,14 @@ defmodule Postgrex.Query do
     statement:      iodata,
     params:         [term] | nil,
     param_formats:  [:binary | :text] | nil,
-    encoders:       [(term -> iodata)] | nil,
+    encoders:       [Postgrex.Types.oid] | [(term -> iodata)] | nil,
     columns:        [String.t] | nil,
     result_formats: [:binary | :text] | nil,
-    decoders:       [(binary -> term)] | nil}
+    decoders:       [Postgrex.Types.oid] | [(binary -> term)] | nil,
+    types:          Postgrex.TypeServer.table | nil}
 
   defstruct [:name, :statement, :params, :param_formats, :encoders, :columns,
-    :result_formats, :decoders]
+    :result_formats, :decoders, :types]
 
   @doc """
   Encodes a prepared query.
@@ -38,19 +40,19 @@ defmodule Postgrex.Query do
   @spec encode(t, (term -> term)) :: t
   def encode(query, mapper \\ fn x -> x end)
 
-  def encode(%Postgrex.Query{params: [_|_], param_formats: nil}, _mapper) do
-    raise ArgumentError, "parameters must be of length 0 for this query"
+  def encode(%Postgrex.Query{param_formats: nil, types: nil} = query, _mapper) do
+    raise ArgumentError, "query #{inspect query} has not been prepared"
+  end
+
+  def encode(%Postgrex.Query{param_formats: nil} = query, _mapper) do
+    raise ArgumentError, "query #{inspect query} has not been described"
   end
 
   def encode(%Postgrex.Query{encoders: nil} = query, _mapper), do: query
 
-  def encode(%Postgrex.Query{encoders: [_|_] = encoders, params: nil}, _mapper) do
-    raise ArgumentError, "parameters must be of length #{length encoders} for this query"
-  end
-
   def encode(query, mapper) do
     %Postgrex.Query{params: params, encoders: encoders} = query
-    case encode_params(params, encoders, mapper, []) do
+    case encode_params(params || [], encoders, mapper, []) do
       :error ->
         raise ArgumentError, "parameters must be of length #{length encoders} for this query"
       params ->
@@ -72,4 +74,49 @@ defmodule Postgrex.Query do
   end
   defp encode_params([], [], _, encoded), do: Enum.reverse(encoded)
   defp encode_params(params, _, _, _) when is_list(params), do: :error
+end
+
+defimpl DBConnection.Query, for: Postgrex.Query do
+
+  def parse(query, _), do: query
+
+  def describe(%Postgrex.Query{param_formats: nil, types: nil} = query, _) do
+    raise ArgumentError, "query #{inspect query} has not been prepared"
+  end
+  def describe(%Postgrex.Query{encoders: encoders, types: nil} = query, _)
+  when is_list(encoders) do
+    query
+  end
+  def describe(query, _) do
+    %Postgrex.Query{encoders: poids, decoders: roids, types: types} = query
+    {pfs, encoders} = encoders(poids, types)
+    {rfs, decoders} = decoders(roids, types)
+    %Postgrex.Query{query | param_formats: pfs, encoders: encoders,
+                            result_formats: rfs, decoders: decoders,
+                            types: nil}
+  end
+
+  def encode(query, opts) do
+    case opts[:encode] || :auto do
+      :auto   -> Postgrex.Query.encode(query)
+      :manual -> query
+    end
+  end
+
+  ## helpers
+
+  defp encoders(oids, types) do
+    oids
+    |> Enum.map(&Postgrex.Types.encoder(&1, types))
+    |> :lists.unzip()
+  end
+
+  defp decoders(nil, _) do
+    {[], nil}
+  end
+  defp decoders(oids, types) do
+    oids
+    |> Enum.map(&Postgrex.Types.decoder(&1, types))
+    |> :lists.unzip()
+  end
 end

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -54,12 +54,3 @@ defmodule Postgrex.Result do
   end
   defp decode_row([], []), do: []
 end
-
-defimpl DBConnection.Result, for: Postgrex.Result do
-  def decode(result, opts) do
-    case opts[:decode] || :auto do
-      :auto   -> Postgrex.Result.decode(result)
-      :manual -> result
-    end
-  end
-end

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -8,49 +8,13 @@ defmodule Postgrex.Result do
     * `rows` - The result set. A list of tuples, each tuple corresponding to a
                row, each element in the tuple corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
-    * `decoders` - List of anonymous functions to decode each column;
   """
 
   @type t :: %__MODULE__{
     command:  atom,
     columns:  [String.t] | nil,
     rows:     [[term] | term] | nil,
-    num_rows: integer,
-    decoders: [(binary -> term)] | nil}
+    num_rows: integer}
 
-  defstruct [command: nil, columns: nil, rows: nil, num_rows: nil,
-             decoders: nil]
-
-  @doc """
-  Decodes a result set.
-
-  It is a no-op if the result was already decoded.
-
-  A mapper function can be given to further process
-  each row, in no specific order.
-  """
-  @spec decode(t, ([term] -> term)) :: t
-  def decode(result_set, mapper \\ fn x -> x end)
-
-  def decode(%Postgrex.Result{decoders: nil} = res, _mapper), do: res
-
-  def decode(res, mapper) do
-    %Postgrex.Result{rows: rows, decoders: decoders} = res
-    rows = decode(rows, decoders, mapper, [])
-    %Postgrex.Result{res | rows: rows, decoders: nil}
-  end
-
-  defp decode([row | rows], decoders, mapper, decoded) do
-    decoded = [mapper.(decode_row(row, decoders)) | decoded]
-    decode(rows, decoders, mapper, decoded)
-  end
-  defp decode([], _, _, decoded), do: decoded
-
-  defp decode_row([nil | rest], [_ | decoders]) do
-    [nil | decode_row(rest, decoders)]
-  end
-  defp decode_row([elem | rest], [decode | decoders]) do
-    [decode.(elem) | decode_row(rest, decoders)]
-  end
-  defp decode_row([], []), do: []
+  defstruct [command: nil, columns: nil, rows: nil, num_rows: nil]
 end

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -54,3 +54,12 @@ defmodule Postgrex.Result do
   end
   defp decode_row([], []), do: []
 end
+
+defimpl DBConnection.Result, for: Postgrex.Result do
+  def decode(result, opts) do
+    case opts[:decode] || :auto do
+      :auto   -> Postgrex.Result.decode(result)
+      :manual -> result
+    end
+  end
+end

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -23,6 +23,7 @@ defmodule Postgrex.Utils do
   @spec default_opts(Keyword.t) :: Keyword.t
   def default_opts(opts) do
     opts
+    |> Keyword.put_new(:backoff_type, :stop)
     |> Keyword.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -23,7 +23,6 @@ defmodule Postgrex.Utils do
   @spec default_opts(Keyword.t) :: Keyword.t
   def default_opts(opts) do
     opts
-    |> Keyword.put_new(:backoff_type, :stop)
     |> Keyword.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 0.1.6"},
+     {:db_connection, "~> 0.1.7"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 0.1"},
+     {:db_connection, "~> 0.1", github: "fishcakez/db_connection"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Postgrex.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:logger, :connection, :decimal],
+    [applications: [:logger, :db_connection, :decimal],
      mod: {Postgrex, []},
      env: [type_server_reap_after: 3 * 60_000]]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:decimal, "~> 1.0"},
+     {:db_connection, "~> 0.1"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 0.1"},
+     {:db_connection, "~> 0.1.6"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Postgrex.Mixfile do
     [{:ex_doc, only: :dev},
      {:earmark, only: :dev},
      {:decimal, "~> 1.0"},
-     {:db_connection, "~> 0.1", github: "fishcakez/db_connection"},
+     {:db_connection, "~> 0.1"},
      {:connection, "~> 1.0"}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
-  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "ec11fbb8ca9ad4f6bd9d4757cc09c88a3b942558", []},
+  "db_connection": {:hex, :db_connection, "0.1.5"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
-  "db_connection": {:hex, :db_connection, "0.1.6"},
+  "db_connection": {:hex, :db_connection, "0.1.7"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
-  "db_connection": {:hex, :db_connection, "0.1.5"},
+  "db_connection": {:hex, :db_connection, "0.1.6"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"backoff": {:hex, :backoff, "1.1.1"},
   "connection": {:hex, :connection, "1.0.2"},
-  "db_connection": {:hex, :db_connection, "0.1.3"},
+  "db_connection": {:git, "https://github.com/fishcakez/db_connection.git", "ec11fbb8ca9ad4f6bd9d4757cc09c88a3b942558", []},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"connection": {:hex, :connection, "1.0.1"},
+%{"backoff": {:hex, :backoff, "1.1.1"},
+  "connection": {:hex, :connection, "1.0.2"},
+  "db_connection": {:hex, :db_connection, "0.1.3"},
   "decimal": {:hex, :decimal, "1.1.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.10.0"}}

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -128,10 +128,10 @@ defmodule LoginTest do
 
         use DBConnection.Proxy
 
-        def handle_close(_, _, _, %{parameters: ref} = state, _) do
+        def handle_close(_, _, _, %{parameters: ref} = state, s) do
           send(self(), {:ref, ref})
           err = RuntimeError.exception("oops")
-          {:disconnect, err, state}
+          {:disconnect, err, state, s}
         end
       end
 
@@ -139,7 +139,7 @@ defmodule LoginTest do
 
       capture_log fn ->
         assert_raise RuntimeError, "oops",
-          fn() -> P.close!(pid, %Postgrex.Query{}, [proxy_mod: BackoffTest]) end
+          fn() -> P.close!(pid, %Postgrex.Query{}, [proxy: BackoffTest]) end
 
         assert {:ok, %Postgrex.Result{}} = P.query(pid, "SELECT 123", [])
 

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -151,4 +151,16 @@ defmodule LoginTest do
       :code.purge(BackoffTest)
     end
   end
+
+  test "after connect function run" do
+    parent = self()
+    after_connect = fn(conn) -> send(parent, P.query(conn, "SELECT 42", [])) end
+    opts = [ hostname: "localhost", username: "postgres",
+             password: "postgres", database: "postgrex_test",
+             after_connect: after_connect ]
+
+    {:ok, _} = P.start_link(opts)
+
+    assert_receive {:ok, %Postgrex.Result{}}
+  end
 end

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -18,7 +18,7 @@ defmodule LoginTest do
 
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts)
-      assert_receive {:EXIT, ^pid, %Postgrex.Error{postgres: %{code: code}}}, 500
+      assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}}, [_|_]}, 500
       assert code in [:invalid_authorization_specification, :invalid_password]
     end
   end
@@ -37,7 +37,7 @@ defmodule LoginTest do
 
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts)
-      assert_receive {:EXIT, ^pid, %Postgrex.Error{postgres: %{code: code}}}
+      assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: code}}}, [_|_]}
       assert code in [:invalid_authorization_specification, :invalid_password]
     end
   end
@@ -93,16 +93,16 @@ defmodule LoginTest do
 
     capture_log fn ->
       opts = [ database: "doesntexist", sync_connect: true ]
-      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_catalog_name}}} =
+      assert {:error, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}} =
              P.start_link(opts)
 
-      assert_receive {:EXIT, _, %Postgrex.Error{postgres: %{code: :invalid_catalog_name}}}
+      assert_receive {:EXIT, _, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
     end
 
     capture_log fn ->
       opts = [ database: "doesntexist" ]
       {:ok, pid} = P.start_link(opts)
-      assert_receive {:EXIT, ^pid, %Postgrex.Error{postgres: %{code: :invalid_catalog_name}}}
+      assert_receive {:EXIT, ^pid, {%Postgrex.Error{postgres: %{code: :invalid_catalog_name}}, [_|_]}}
     end
   end
 
@@ -113,7 +113,7 @@ defmodule LoginTest do
 
     capture_log fn ->
       assert {:ok, pid} = P.start_link(opts)
-      assert_receive {:EXIT, ^pid, %Postgrex.Error{message: message}}, 500
+      assert_receive {:EXIT, ^pid, {%Postgrex.Error{message: message}, [_|_]}}, 500
       assert message == "tcp connect: non-existing domain - :nxdomain"
     end
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -622,9 +622,11 @@ defmodule QueryTest do
     conn = context[:pid]
 
     Process.flag(:trap_exit, true)
-    assert %Postgrex.Error{} = query("SELECT pg_sleep(0.1)", [], [timeout: 50])
+    capture_log fn ->
+      assert %Postgrex.Error{} = query("SELECT pg_sleep(0.1)", [], [timeout: 50])
 
-    assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, _}}
+      assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, _}}
+    end
   end
 
   test "active client cancel", context do
@@ -649,9 +651,10 @@ defmodule QueryTest do
 
     :timer.sleep(100)
     Process.flag(:trap_exit, true)
-    Process.exit(pid, :shutdown)
-
-    assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, [_|_]}}
+    capture_log fn ->
+      Process.exit(pid, :shutdown)
+      assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, [_|_]}}
+    end
   end
 
   test "queued client cancel", context do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -698,4 +698,19 @@ defmodule QueryTest do
       assert_received [[:void]]
     end)
   end
+
+  test "raise when trying to execute unprepared query", context do
+    assert_raise ArgumentError, ~r/has not been prepared/,
+      fn -> execute(%Postgrex.Query{name: "hi", statement: "BEGIN"}, []) end
+  end
+
+  test "raise when trying to prepare or close reserved query", context do
+    assert_raise ArgumentError, ~r/uses reserved name/,
+      fn -> prepare("POSTGREX_BEGIN", "COMMIT") end
+
+    query = prepare("BEGIN", "BEGIN")
+    query = %Postgrex.Query{query | name: "POSTGREX_BEGIN"}
+
+    assert_raise ArgumentError, ~r/uses reserved name/, fn -> close(query) end
+  end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -486,6 +486,11 @@ defmodule QueryTest do
     assert res.rows == [[2, 4], [6, 8]]
   end
 
+  test "multi row result struct with decode mapper", context do
+    map = &Enum.map(&1, fn x -> x * 2 end)
+    assert [[2,4], [6,8]] = query("VALUES (1, 2), (3, 4)", [], decode_mapper: map)
+  end
+
   test "insert", context do
     :ok = query("CREATE TABLE test (id int, text text)", [])
     [] = query("SELECT * FROM test", [])

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -638,7 +638,7 @@ defmodule QueryTest do
     conn = context[:pid]
     :sys.suspend(conn)
 
-    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [queue_timeout: 0]))
+    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [pool_timeout: 0]))
 
     Process.flag(:trap_exit, true)
     :sys.resume(conn)
@@ -672,7 +672,7 @@ defmodule QueryTest do
 
     assert_receive [[:void]], 1000
 
-    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [queue_timeout: 0]))
+    assert {:timeout, _} = catch_exit(query("SELECT 42", [], [pool_timeout: 0]))
     assert [[42]] = query("SELECT 42", [])
 
      Enum.each(2..10, fn _ ->

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -713,4 +713,8 @@ defmodule QueryTest do
 
     assert_raise ArgumentError, ~r/uses reserved name/, fn -> close(query) end
   end
+
+  test "query struct interpolates to statement" do
+    assert "#{%Postgrex.Query{statement: "BEGIN"}}" == "BEGIN"
+  end
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -564,6 +564,14 @@ defmodule QueryTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
+  test "connection works on custom transactions", context do
+    assert :ok = query("BEGIN", [])
+    assert :ok = query("COMMIT", [])
+    assert :ok = query("BEGIN", [])
+    assert :ok = query("ROLLBACK", [])
+    assert [[42]] = query("SELECT 42", [])
+  end
+
   test "connection works after failure in prepare", context do
     assert %Postgrex.Error{} = prepare("bad", "wat")
     assert [[42]] = query("SELECT 42", [])
@@ -586,7 +594,7 @@ defmodule QueryTest do
 
   test "connection reuses prepared query after failure in preparing state", context do
     %Postgrex.Query{} = query = prepare("", "SELECT 41")
-    assert %Postgrex.Error{} = query("wat", []) 
+    assert %Postgrex.Error{} = query("wat", [])
     assert [[41]] = execute(query, [])
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -4,7 +4,7 @@ defmodule QueryTest do
   alias Postgrex.Connection, as: P
 
   setup do
-    opts = [ database: "postgrex_test" ]
+    opts = [ database: "postgrex_test", backoff_type: :stop ]
     {:ok, pid} = P.start_link(opts)
     {:ok, [pid: pid]}
   end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -635,7 +635,7 @@ defmodule QueryTest do
     Process.flag(:trap_exit, true)
     assert %Postgrex.Error{} = query("SELECT pg_sleep(0.1)", [], [timeout: 50])
 
-    assert_receive {:EXIT, ^conn, {:shutdown, :timeout}}
+    assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, _}}
   end
 
   test "active client cancel", context do
@@ -647,7 +647,7 @@ defmodule QueryTest do
     Process.flag(:trap_exit, true)
     :sys.resume(conn)
 
-    assert_receive {:EXIT, ^conn, {:shutdown, :cancel}}
+    assert [[42]] = query("SELECT 42", [])
   end
 
   test "active client DOWN", context do
@@ -662,7 +662,7 @@ defmodule QueryTest do
     Process.flag(:trap_exit, true)
     Process.exit(pid, :shutdown)
 
-    assert_receive {:EXIT, ^conn, {:shutdown, :DOWN}}
+    assert_receive {:EXIT, ^conn, {%DBConnection.Error{}, [_|_]}}
   end
 
   test "queued client cancel", context do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -121,10 +121,10 @@ defmodule Postgrex.TestHelper do
     end
   end
 
-  defmacro execute(query, opts \\ []) do
+  defmacro execute(query, params, opts \\ []) do
     quote do
       case Postgrex.Connection.execute(var!(context)[:pid], unquote(query),
-                                       unquote(opts)) do
+                                       unquote(params), unquote(opts)) do
         {:ok, %Postgrex.Result{rows: nil}} -> :ok
         {:ok, %Postgrex.Result{rows: rows}} -> rows
         {:error, %Postgrex.Error{} = err} -> err

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -142,6 +142,13 @@ defmodule Postgrex.TestHelper do
     end
   end
 
+  defmacro transaction(fun, opts \\ []) do
+    quote do
+      Postgrex.Connection.transaction(var!(context)[:pid], unquote(fun),
+                                      unquote(opts))
+    end
+  end
+
   def capture_log(fun) do
     Logger.remove_backend(:console)
     fun.()

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -1,0 +1,90 @@
+defmodule TransactionTest do
+  use ExUnit.Case, async: true
+  import Postgrex.TestHelper
+  alias Postgrex.Connection, as: P
+
+  setup do
+    opts = [ database: "postgrex_test", transactions: :strict,
+             backoff_type: :stop ]
+    {:ok, pid} = P.start_link(opts)
+    {:ok, [pid: pid]}
+  end
+
+  test "connection works after failure during commit transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+       P.query(conn, "insert into uniques values (1), (1);", [])
+     assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
+       P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "connection works after failure during rollback transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+       P.query(conn, "insert into uniques values (1), (1);", [])
+     assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
+       P.query(conn, "SELECT 42", [])
+       P.rollback(conn, :oops)
+    end) == {:error, :oops}
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  test "query begin returns error", context do
+    Process.flag(:trap_exit, true)
+
+    capture_log fn ->
+      assert (err = %Postgrex.Error{message: "unexpected postgres status: transaction"}) = query("BEGIN", [])
+
+      pid = context[:pid]
+      assert_receive {:EXIT, ^pid, {^err, _}}
+    end
+  end
+
+  test "query commit returns error", context do
+    Process.flag(:trap_exit, true)
+
+    assert transaction(fn(conn) ->
+      capture_log fn ->
+        assert {:error, err = %Postgrex.Error{message: "unexpected postgres status: idle"}} =
+          P.query(conn, "ROLLBACK", [])
+
+        pid = context[:pid]
+        assert_receive {:EXIT, ^pid, {^err, _}}
+      end
+      :hi
+    end) == {:ok, :hi}
+  end
+
+  test "checkout when in transaction disconnects", context do
+    Process.flag(:trap_exit, true)
+
+    pid = context[:pid]
+    :sys.replace_state(pid,
+      fn(%{mod_state: %{state: state} = mod} = conn) ->
+        %{conn | mod_state: %{mod | state: %{state | postgres: :transaction}}}
+      end)
+    capture_log fn ->
+      assert {{%Postgrex.Error{message: "unexpected postgres status: transaction"}, [_|_]}, _} =
+        catch_exit(query("SELECT 42", []))
+    end
+  end
+
+  test "ping when transaction state mismatch disconnects" do
+    Process.flag(:trap_exit, true)
+
+    opts = [ database: "postgrex_test", transactions: :strict,
+             idle_timeout: 10, backoff_type: :stop ]
+    {:ok, pid} = P.start_link(opts)
+
+    capture_log fn ->
+      :sys.replace_state(pid,
+        fn(%{mod_state: %{state: state} = mod} = conn) ->
+          %{conn | mod_state: %{mod | state: %{state | postgres: :transaction}}}
+        end)
+      assert_receive {:EXIT, ^pid, {%Postgrex.Error{message: "unexpected postgres status: idle"}, [_|_]}}
+    end
+  end
+end


### PR DESCRIPTION
This is WIP.

Issues:

- [x] There are failing tests because `Postgrex.Connection.stop/1` has not been replaced. I could not come up with a good method to stop a supervisor without requiring Elixir 1.2.
- [x] The parameter map is always sent to the client process and back but rarely used. Previously they were not sent. What are the use cases for this function?
- [x] Timeouts are not handled correctly as a socket receive timeout of 5000ms is always used, which means a longer timeout will not be honoured. This can be solved by moving the timeout from the protocol's state to its request "status" term.

There are two optimisations in this change because the `DBConnection` API is not exactly equivalent to the old `Postgrex.Connection`:

* Notifications are sent as soon as they are received and are not accumulated.
* Type information for a query can be looked up without blocking the connection. I am unsure how useful it is as the client will likely be holding on to the connection about to execute.

Will need to do benchmark/profile to check performance does not regress before merging.

I have not added any new features in this PR and would prefer these to come one by one in separate PRs. The features (pooling, transactions, network failure handling, idle timeout) require implementing simple callbacks, documenting options and/or wrapping `DBConnection` calls so are almost free.