### PR TITLE
Do not shutdown on binding error

### DIFF
--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -544,6 +544,12 @@ defmodule QueryTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
+  test "connection works after failure in binding state", context do
+    assert %Postgrex.Error{postgres: %{code: :invalid_text_representation}} =
+      query("insert into uniques values (CAST($1::text AS int))", ["invalid"])
+    assert [[42]] = query("SELECT 42", [])
+  end
+
   test "connection works after failure in executing state", context do
     assert %Postgrex.Error{postgres: %{code: :unique_violation}} =
       query("insert into uniques values (1), (1);", [])


### PR DESCRIPTION
This is a bug fix for tag `v0.10.0`. The bug is fixed on master by coincidence. Could we have a branch for `v0.10` so we can backport fixes without introducing prepare/execute into `v0.10.*`? This PR is not mergable.

This bug was reported in #129  but was hidden by an issue with Ecto (see https://github.com/elixir-lang/ecto/issues/1161).