### PR TITLE
Specify version for ex_doc and earmark deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,8 @@ defmodule Postgrex.Mixfile do
   end
 
   defp deps do
-    [{:ex_doc, only: :dev},
-     {:earmark, only: :dev},
+    [{:ex_doc, "~> 0.10", only: :dev},
+     {:earmark, "~> 0.1", only: :dev},
      {:decimal, "~> 1.0"},
      {:connection, "~> 1.0"}]
   end


### PR DESCRIPTION
Fixes an error with newer hex:
```
** (Mix) earmark is missing its version requirement, use ">= 0.0.0" if it should match any version
```