### PR TITLE
Add connection_id to Postgrex.Result and Postgrex.Error. Fixes #137.

### DIFF
--- a/lib/postgrex/error.ex
+++ b/lib/postgrex/error.ex
@@ -1,5 +1,5 @@
 defmodule Postgrex.Error do
-  defexception [:message, :postgres]
+  defexception [:message, :postgres, :connection_id]
 
   @nonposix_errors [:closed, :timeout]
 

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -8,13 +8,15 @@ defmodule Postgrex.Result do
     * `rows` - The result set. A list of tuples, each tuple corresponding to a
                row, each element in the tuple corresponds to a column;
     * `num_rows` - The number of fetched or affected rows;
+    * `connection_id` - The OS pid of the Postgres backend that executed the query;
   """
 
   @type t :: %__MODULE__{
     command:  atom,
     columns:  [String.t] | nil,
     rows:     [[term] | term] | nil,
-    num_rows: integer}
+    num_rows: integer,
+    connection_id: pos_integer}
 
-  defstruct [command: nil, columns: nil, rows: nil, num_rows: nil]
+  defstruct [command: nil, columns: nil, rows: nil, num_rows: nil, connection_id: nil]
 end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -696,4 +696,15 @@ defmodule QueryTest do
   test "query struct interpolates to statement" do
     assert "#{%Postgrex.Query{statement: "BEGIN"}}" == "BEGIN"
   end
+
+  test "connection_id", context do
+    assert {:ok, %Postgrex.Result{connection_id: connection_id, rows: [[backend_pid]]}} =
+      Postgrex.Connection.query(context[:pid], "SELECT pg_backend_pid()", [])
+    assert is_integer(connection_id)
+    assert connection_id == backend_pid
+
+    assert {:error, %Postgrex.Error{connection_id: connection_id}} =
+      Postgrex.Connection.query(context[:pid], "FOO BAR", [])
+    assert is_integer(connection_id)
+  end
 end


### PR DESCRIPTION
I don't feel good about retrieving the `connection_id` all over the place, but I couldn't come up with anything nicer. Recommendations?

Also I'm not sure about whether the key should be `connection_id` or `backend_pid`. IMO from the Postgre(s|x) perspective it's clearly the `backend_pid`, only from Ecto's ORM-independent perspective does the `backend_pid` become the `connection_id`.