### PR TITLE
Delay row decoding

### DIFF
--- a/lib/postgrex/messages.ex
+++ b/lib/postgrex/messages.ex
@@ -97,9 +97,8 @@ defmodule Postgrex.Messages do
   end
 
   # data_row
-  def parse(<<count :: uint16, rest :: binary>>, ?D, _size) do
-    values = decode_row_values(rest, count)
-    msg_data_row(values: values)
+  def parse(<<_ :: uint16, rest :: binary>>, ?D, _size) do
+    msg_data_row(values: rest)
   end
 
   # notify
@@ -295,16 +294,6 @@ defmodule Postgrex.Messages do
     field = row_field(name: name, table_oid: table_oid, column: column, type_oid: type_oid,
                       type_size: type_size, type_mod: type_mod, format: format)
     {field, rest}
-  end
-
-  defp decode_row_values("", 0), do: []
-
-  defp decode_row_values(<<-1 :: int32, rest :: binary>>, count) do
-    [nil | decode_row_values(rest, count-1)]
-  end
-
-  defp decode_row_values(<<length :: uint32, value :: binary(length), rest :: binary>>, count) do
-    [value | decode_row_values(rest, count-1)]
   end
 
   Enum.each(@auth_types, fn {type, value} ->

--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -97,13 +97,13 @@ defimpl DBConnection.Query, for: Postgrex.Query do
   end
   defp do_decode([], _, _, decoded), do: decoded
 
-  defp decode_row([nil | rest], [_ | decoders], decoded) do
+  defp decode_row(<<-1 :: int32, rest :: binary>>, [_ | decoders], decoded) do
     decode_row(rest, decoders, [nil | decoded])
   end
-  defp decode_row([elem | rest], [decode | decoders], decoded) do
-    decode_row(rest, decoders, [decode.(elem) | decoded])
+  defp decode_row(<<len :: uint32, value :: binary(len), rest :: binary>>, [decode | decoders], decoded) do
+    decode_row(rest, decoders, [decode.(value) | decoded])
   end
-  defp decode_row([], [], decoded), do: Enum.reverse(decoded)
+  defp decode_row(<<>>, [], decoded), do: Enum.reverse(decoded)
 end
 
 defimpl String.Chars, for: Postgrex.Query do

--- a/lib/postgrex/result.ex
+++ b/lib/postgrex/result.ex
@@ -14,7 +14,7 @@ defmodule Postgrex.Result do
   @type t :: %__MODULE__{
     command:  atom,
     columns:  [String.t] | nil,
-    rows:     [[term] | term] | nil,
+    rows:     [[term] | binary] | nil,
     num_rows: integer,
     connection_id: pos_integer}
 


### PR DESCRIPTION
Only traverse and reverse the row once, instead of twice.