### PR TITLE
Skip describe when executing described query

### DIFF
--- a/lib/postgrex/query.ex
+++ b/lib/postgrex/query.ex
@@ -9,7 +9,7 @@ defmodule Postgrex.Query do
     * `columns` - The column names;
     * `result_formats` - List of formats for each column is decoded from;
     * `decoders` - List of anonymous functions to decode each column;
-    * `types` - The type serber table to fetch the type information from;
+    * `types` - The type server table to fetch the type information from;
   """
 
   @type t :: %__MODULE__{
@@ -29,7 +29,11 @@ end
 defimpl DBConnection.Query, for: Postgrex.Query do
   import Postgrex.BinaryUtils
 
-  def parse(query, _), do: query
+  def parse(%{name: name, statement: statement} = query, _) do
+    # for query table to match on two identical statements they must be equal
+    %{query | name: IO.iodata_to_binary(name),
+      statement: IO.iodata_to_binary(statement)}
+  end
 
   def describe(query, _) do
     %Postgrex.Query{encoders: poids, decoders: roids, types: types} = query

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -577,6 +577,13 @@ defmodule QueryTest do
     assert [[41]] = execute(query, [])
   end
 
+  test "connection forces prepare on execute after prepare of same name", context do
+    %Postgrex.Query{} = query41 = prepare("", "SELECT 41")
+    assert %Postgrex.Query{} = query42 = prepare("", "SELECT 42")
+    assert [[42]] = execute(query42, [])
+    assert [[41]] = execute(query41, [])
+  end
+
   test "async test", context do
     self_pid = self
     Enum.each(1..10, fn _ ->


### PR DESCRIPTION
Previously when executing a query prepared on another connection, the connection would try to execute, prepare and then execute the query. This took 3 round trips. This change does prepare and execute in 1 round trip when the query was already described. Therefore when we use prepared cached queries in Ecto we only need to do one 2 round trip to postgres per cached query.

Previously when executing a prepared query on a connection with a different query prepared with the same name, the different query would be executed. This change ensures the names and statements match before executing.