### PR TITLE
Test savepoint transactions

### DIFF
--- a/lib/postgrex/connection.ex
+++ b/lib/postgrex/connection.ex
@@ -266,12 +266,15 @@ defmodule Postgrex.Connection do
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
     * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection`
+    `start_link/1`, see `DBConnection;
+    * `:mode` - Set to `:savepoint` to use savepoints instead of an SQL
+    transaction, otherwise set to `:transaction` (default: `:transaction`);
+
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal
-  transactions and requests. The `:pool` will be used for all requests inside
-  the transaction function.
+  transactions and requests. The `:pool` and `:mode` will be used for all
+  requests inside the transaction function.
 
   ## Example
 

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -3,13 +3,19 @@ defmodule TransactionTest do
   import Postgrex.TestHelper
   alias Postgrex.Connection, as: P
 
-  setup do
-    opts = [ database: "postgrex_test", transactions: :strict,
+  setup context do
+    transactions =
+      case context[:mode] do
+        :transaction -> :strict
+        :savepoint   -> :naive
+      end
+    opts = [ database: "postgrex_test", transactions: transactions,
              backoff_type: :stop ]
     {:ok, pid} = P.start_link(opts)
     {:ok, [pid: pid]}
   end
 
+  @tag mode: :transaction
   test "connection works after failure during commit transaction", context do
     assert transaction(fn(conn) ->
       assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
@@ -21,6 +27,7 @@ defmodule TransactionTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
+  @tag mode: :transaction
   test "connection works after failure during rollback transaction", context do
     assert transaction(fn(conn) ->
       assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
@@ -32,6 +39,7 @@ defmodule TransactionTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
+  @tag mode: :transaction
   test "query begin returns error", context do
     Process.flag(:trap_exit, true)
 
@@ -43,6 +51,7 @@ defmodule TransactionTest do
     end
   end
 
+  @tag mode: :transaction
   test "query commit returns error", context do
     Process.flag(:trap_exit, true)
 
@@ -58,6 +67,7 @@ defmodule TransactionTest do
     end) == {:ok, :hi}
   end
 
+  @tag mode: :transaction
   test "checkout when in transaction disconnects", context do
     Process.flag(:trap_exit, true)
 
@@ -72,6 +82,7 @@ defmodule TransactionTest do
     end
   end
 
+  @tag mode: :transaction
   test "ping when transaction state mismatch disconnects" do
     Process.flag(:trap_exit, true)
 
@@ -86,5 +97,32 @@ defmodule TransactionTest do
         end)
       assert_receive {:EXIT, ^pid, {%Postgrex.Error{message: "unexpected postgres status: idle"}, [_|_]}}
     end
+  end
+
+  @tag mode: :savepoint
+  test "savepoint transaction releases savepoint", context do
+    :ok = query("BEGIN", [])
+    assert transaction(fn(conn) ->
+      assert {:ok, _} = P.query(conn, "SELECT 42", [])
+      :hi
+    end, [mode: :savepoint]) == {:ok, :hi}
+    assert [[42]] = query("SELECT 42", [])
+    assert %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}} =
+      query("RELEASE SAVEPOINT postgrex_savepoint", [])
+    assert :ok = query("ROLLBACK", [])
+  end
+
+  @tag mode: :savepoint
+  test "savepoint transaction rolls back to savepoint and releases", context do
+    assert :ok = query("BEGIN", [])
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [])
+      P.rollback(conn, :oops)
+    end, [mode: :savepoint]) == {:error, :oops}
+    assert [[42]] = query("SELECT 42", [])
+    assert %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}} =
+      query("RELEASE SAVEPOINT postgrex_savepoint", [])
+    assert :ok = query("ROLLBACK", [])
   end
 end


### PR DESCRIPTION
The tests don't actually use savepoints yet, which means savepoint transactions aren't usable in postgrex itself.