### PR TITLE
Handle parse error when part of handle_execute(_close)

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -561,6 +561,8 @@ defmodule Postgrex.Protocol do
       {:ok, msg_parse_complete(), buffer} when prepare == :parse ->
         query_put(s, query)
         ok(s, query, buffer)
+      {:ok, msg_error(fields: fields), buffer} when prepare == :parse_execute ->
+        sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         sync(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -492,6 +492,16 @@ defmodule QueryTest do
     assert [[42]] = query("SELECT 42", [])
   end
 
+  test "prepare query and execute different query with same name", context do
+    assert (%Postgrex.Query{} = query42) = prepare("select", "SELECT 42")
+    assert close(query42) == :ok
+    assert %Postgrex.Query{} = prepare("select", "SELECT 41")
+    assert %Postgrex.Error{postgres: %{code: :duplicate_prepared_statement}} =
+      execute(query42, [])
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
   test "prepare, close and execute", context do
     assert (%Postgrex.Query{} = query) = prepare("reuse", "SELECT $1::int")
     assert [[42]] = execute(query, [42])


### PR DESCRIPTION
Previously we did not handle the case where a parse error occurs and a `sync` has already been sent. Another `sync` was sent and only one `ready` was received. This left another `ready` packet in the buffer and crashes the next request.

Closes #149.