### PR TITLE
Add basic support for built-in postgres point type

### DIFF
--- a/lib/postgrex/builtins.ex
+++ b/lib/postgrex/builtins.ex
@@ -146,3 +146,18 @@ defmodule Postgrex.MACADDR do
 
   defstruct [address: nil]
 end
+
+defmodule Postgrex.Point do
+  @moduledoc """
+  Struct for Postgres point.
+
+  ## Fields
+    * `x`
+    * `y`
+  """
+  @type t :: %__MODULE__{x: float, y: float}
+
+  defstruct [
+    x: nil,
+    y: nil]
+end

--- a/lib/postgrex/extensions/point.ex
+++ b/lib/postgrex/extensions/point.ex
@@ -1,0 +1,16 @@
+defmodule Postgrex.Extensions.Point do
+  @moduledoc false
+  import Postgrex.BinaryUtils
+  use Postgrex.BinaryExtension, send: "point_send"
+
+  def encode(_, %Postgrex.Point{x: x, y: y}, _, _),
+    do: <<x::float64, y::float64>>
+
+  def encode(type_info, value, _, _) do
+    raise ArgumentError,
+      Postgrex.Utils.encode_msg(type_info, value, Postgrex.Point)
+  end
+
+  def decode(_, <<x::float64, y::float64>>, _, _),
+    do: %Postgrex.Point{x: x, y: y}
+end

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -16,6 +16,7 @@ defmodule Postgrex.Utils do
     Postgrex.Extensions.Network,
     Postgrex.Extensions.Numeric,
     Postgrex.Extensions.OID,
+    Postgrex.Extensions.Point,
     Postgrex.Extensions.Range,
     Postgrex.Extensions.Raw,
     Postgrex.Extensions.Record,

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -109,6 +109,14 @@ defmodule QueryTest do
            query("SELECT interval '1 year 2 months 40 days 3 hours 2 minutes'", [])
   end
 
+  test "decode point", context do
+    assert [[%Postgrex.Point{x: -97.5, y: 100.1}]] == query("SELECT point(-97.5, 100.1)::point", [])
+  end
+
+  test "encode point", context do
+    assert [[%Postgrex.Point{x: -97, y: 100}]] == query("SELECT $1::point", [%Postgrex.Point{x: -97, y: 100}])
+  end
+
   test "decode record", context do
     assert [[{1, "2"}]] = query("SELECT (1, '2')::composite1", [])
     assert [[[{1, "2"}]]] = query("SELECT ARRAY[(1, '2')::composite1]", [])


### PR DESCRIPTION
This is a rebased version of #126, updated to account for the upstream extension changes.

Thanks to @jbavari for doing the hard work of figuring out how to create the type and all the initial coding on this.