### PR TITLE
Use PGPORT as an integer.

### DIFF
--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -52,8 +52,14 @@ defmodule Postgrex.Utils do
     |> Keyword.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")
-    |> Keyword.put_new(:port, System.get_env("PGPORT"))
+    |> Keyword.put_new(:port, parse_port_number(System.get_env("PGPORT")))
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  end
+
+  defp parse_port_number(nil), do: nil
+
+  defp parse_port_number(port) when is_binary(port) do
+    String.to_integer(port)
   end
 
   @doc """

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -136,4 +136,34 @@ defmodule LoginTest do
 
     assert_receive {:ok, %Postgrex.Result{}}
   end
+
+  test "translates port to integer" do
+    opts = []
+    previous_port = System.get_env("PGPORT")
+    try do
+      set_port_number("12345")
+      assert 12345 == P.Utils.default_opts(opts)[:port]
+    after
+      set_port_number(previous_port)
+    end
+  end
+
+  test "ignores pgport if non existent" do
+    opts = []
+    previous_port = System.get_env("PGPORT")
+    try do
+      System.delete_env("PGPORT")
+      assert nil == P.Utils.default_opts(opts)[:port]
+    after
+      set_port_number(previous_port)
+    end
+  end
+
+  defp set_port_number(nil) do
+    System.delete_env("PGPORT")
+  end
+
+  defp set_port_number(port) when is_binary(port) do
+    System.put_env("PGPORT", port)
+  end
 end


### PR DESCRIPTION
This fixes :inet_tcp.getserv/1 receiving a binary which it has no matching available.

If there is a smarter way of doing this, let me know! This is my first piece of code in Elixir. :tada: