### PR TITLE
Update postgrex.ex

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -278,7 +278,7 @@ defmodule Postgrex do
     * `:queue` - Whether to wait for connection in a queue (default: `true`);
     * `:timeout` - Transaction timeout (default: `#{@timeout}`);
     * `:pool` - The pool module to use, must match that set on
-    `start_link/1`, see `DBConnection;
+    `start_link/1`, see `DBConnection`;
     * `:mode` - Set to `:savepoint` to use savepoints instead of an SQL
     transaction, otherwise set to `:transaction` (default: `:transaction`);
 


### PR DESCRIPTION
Doc comment for transaction function had unclosed quote ("DBConnection" line 281). It is mangling the output on hexdocs currently.