### PR TITLE
Fix result set truncation when functions that raise notices are called during query execution

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -739,7 +739,7 @@ defmodule Postgrex.Protocol do
       {:ok, msg_command_complete(tag: tag), buffer} ->
         complete(s, status, query, rows, tag, buffer)
       {:ok, msg, buffer} ->
-        execute_recv(handle_msg(s, status, msg), status, query, buffer)
+        execute_recv(handle_msg(s, status, msg), status, query, rows, buffer)
       {:disconnect, _, _} = dis ->
         dis
     end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -682,4 +682,16 @@ defmodule QueryTest do
     :timer.sleep(20)
     assert {:ok, _} = P.query(pid, "SELECT 42", [])
   end
+
+  test "notices raised by functions do not reset rows", context do
+    assert :ok = query("""
+    CREATE FUNCTION raise_notice_and_return(what integer) RETURNS integer AS $$
+    BEGIN
+      RAISE NOTICE 'notice %', what;
+      RETURN what;
+    END;
+    $$ LANGUAGE plpgsql;
+    """, [])
+    assert [[1], [2]] = query("SELECT raise_notice_and_return(x) FROM generate_series(1, 2) AS x", [])
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -73,6 +73,8 @@ cmds =
                ~s(psql -U postgres -d postgrex_test -c "CREATE EXTENSION IF NOT EXISTS hstore;")]
     String.to_float(pg_version) == 9.0 ->
       cmds ++ [~s(psql -U postgres -d postgrex_test -f "#{pg_path}/contrib/hstore.sql")]
+    String.to_float(pg_version) < 9.0 ->
+      cmds ++ [~s(psql -U postgres -d postgrex_test -c "CREATE LANGUAGE plpgsql;")]
     true ->
       cmds
 end


### PR DESCRIPTION
If a function called while executing a query raises a notice, rows returned prior to calling that function will be dropped. This change reinjects the previous rows into `execute_recv/5` rather than falling back to `excute_recv/4`.

Test is included. Let me know if you have any questions.

Thanks!