### PR TITLE
Add `:decode_binary` option to copy decoded values

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -46,6 +46,13 @@ defmodule Postgrex do
     * `:extensions` - A list of `{module, opts}` pairs where `module` is
     implementing the `Postgrex.Extension` behaviour and `opts` are the
     extension options;
+    * `:decode_binary` - Either `:copy` to copy binary values when decoding with
+    default extensions that return binaries or `:reference` to use a reference
+    counted binary of the binary received from the socket. Referencing a
+    potentially larger binary can be more efficient if the binary value is going
+    to be garbaged collected soon because a copy is avoided. However the larger
+    binary can not be garbage collected until all references are garbage
+    collected (defaults to `:copy`);
     * `:prepare` - How to prepare queries, either `:named` to use named queries
     or `:unnamed` to force unnamed queries (default: `:named`);
     * `:after_connect` - A function to run on connect, either a 1-arity fun

--- a/lib/postgrex/binary_extension.ex
+++ b/lib/postgrex/binary_extension.ex
@@ -11,6 +11,8 @@ defmodule Postgrex.BinaryExtension do
       def matching(_), do: unquote(matching)
 
       def format(_), do: :binary
+
+      defoverridable [init: 2]
     end
   end
 end

--- a/lib/postgrex/extensions/json.ex
+++ b/lib/postgrex/extensions/json.ex
@@ -4,28 +4,44 @@ defmodule Postgrex.Extensions.JSON do
 
   This extension is not used by default, it needs to be included in the
   `:extensions` option to `Postgrex.start_link/1`.
+
+  ## Options
+
+    * `:library` - The module to encode and decode JSON binaries, calls
+    `module.encode!/1` to encode and `module.decode!/1` to decode (required);
+    * `:decode_binary` - Either `:copy` to copy binary values before decoding
+    with the library module or `:reference` to use a reference counted binary of
+    the binary received from the socket. Referencing a potentially larger binary
+    can be more efficient if the binary value is going to be garbaged collected
+    soon because a copy is avoided. However the larger binary can not be garbage
+    collected until all references are garbage collected (defaults to `:copy`);
   """
 
   alias Postgrex.TypeInfo
 
   @behaviour Postgrex.Extension
 
-  def init(_parameters, opts),
-    do: Keyword.fetch!(opts, :library)
+  def init(_parameters, opts) do
+    {Keyword.get(opts, :decode_binary, :copy), Keyword.fetch!(opts, :library)}
+  end
 
-  def matching(_library),
+  def matching(_),
     do: [type: "json", type: "jsonb"]
 
-  def format(_library),
+  def format(_),
     do: :binary
 
-  def encode(%TypeInfo{type: "json"}, map, _state, library),
+  def encode(%TypeInfo{type: "json"}, map, _state, {_, library}),
     do: library.encode!(map)
-  def encode(%TypeInfo{type: "jsonb"}, map, _state, library),
-    do: <<1, library.encode!(map)::binary>>
+  def encode(%TypeInfo{type: "jsonb"}, map, _state, {_, library}),
+    do: [1 | library.encode!(map)]
 
-  def decode(%TypeInfo{type: "json"}, json, _state, library),
+  def decode(%TypeInfo{type: "json"}, json, _state, {:reference, library}),
     do: library.decode!(json)
-  def decode(%TypeInfo{type: "jsonb"}, <<1, json::binary>>, _state, library),
+  def decode(%TypeInfo{type: "json"}, json, _state, {:copy, library}),
+    do: json |> :binary.copy() |> library.decode!()
+  def decode(%TypeInfo{type: "jsonb"}, <<1, json::binary>>, _state, {:reference, library}),
     do: library.decode!(json)
+  def decode(%TypeInfo{type: "jsonb"}, <<1, json::binary>>, _state, {:copy, library}),
+    do: json |> :binary.copy() |> library.decode!()
 end

--- a/lib/postgrex/extensions/raw.ex
+++ b/lib/postgrex/extensions/raw.ex
@@ -5,12 +5,16 @@ defmodule Postgrex.Extensions.Raw do
       send: "byteasend", send: "enum_send", send: "unknownsend",
       type: "citext"]
 
+  def init(_, opts), do: Keyword.fetch!(opts, :decode_binary)
+
   def encode(_, bin, _, _) when is_binary(bin),
     do: bin
   def encode(type_info, value, _, _) do
     raise ArgumentError, Postgrex.Utils.encode_msg(type_info, value, "a binary")
   end
 
-  def decode(_, bin, _, _),
+  def decode(_, bin, _, :reference),
     do: bin
+  def decode(_, bin, _, :copy),
+    do: :binary.copy(bin)
 end

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -41,7 +41,9 @@ defmodule Postgrex.Protocol do
     timeout    = opts[:timeout] || @timeout
     sock_opts  = [send_timeout: timeout] ++ (opts[:socket_options] || [])
     custom     = opts[:extensions] || []
-    extensions = custom ++ Postgrex.Utils.default_extensions()
+    decode_bin = opts[:decode_binary] || :copy
+    ext_opts   = [decode_binary: decode_bin]
+    extensions = custom ++ Postgrex.Utils.default_extensions(ext_opts)
     ssl?       = opts[:ssl] || false
     types?     = Keyword.fetch!(opts, :types)
     null       = opts[:null]
@@ -60,7 +62,7 @@ defmodule Postgrex.Protocol do
 
     s = %__MODULE__{timeout: timeout, postgres: postgres, null: null}
 
-    types_key = if types?, do: {host, port, Keyword.fetch!(opts, :database), custom}
+    types_key = if types?, do: {host, port, Keyword.fetch!(opts, :database), decode_bin, custom}
     status = %{opts: opts, types_key: types_key, types_ref: nil,
                types_table: nil, extensions: extensions, extension_info: nil,
                prepare: prepare}

--- a/lib/postgrex/types.ex
+++ b/lib/postgrex/types.ex
@@ -89,11 +89,11 @@ defmodule Postgrex.Types do
 
       %TypeInfo{
         oid: oid,
-        type: type,
-        send: send,
-        receive: receive,
-        output: output,
-        input: input,
+        type: :binary.copy(type),
+        send: :binary.copy(send),
+        receive: :binary.copy(receive),
+        output: :binary.copy(output),
+        input: :binary.copy(input),
         array_elem: array_oid,
         base_type: base_oid,
         comp_elems: comp_oids}

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -65,8 +65,9 @@ defmodule Postgrex.Utils do
   @doc """
   List all default extensions.
   """
-  def default_extensions() do
-    unquote(Enum.map(@extensions, &{&1, nil}))
+  @spec default_extensions(Keyword.t) :: [{module(), Keyword.t}]
+  def default_extensions(opts \\ []) do
+    Enum.map(@extensions, &{&1, opts})
   end
 
   @doc """


### PR DESCRIPTION
`:decode_binary` is either `:copy` or `:reference`.

* `:copy` uses `:binary.copy/1` to copy values decoded as binaries.
* `:reference` uses a reference counted binary from the binary streamed from the
socket.

If binaries are being held on to for a substantial period of time, sent to
other process, or inserted into ETS it may prevent garbage collection of a
larger binary. This option copies by default so that extra memory is not
consumed. If binaries are going to be garbage collected soon it will be
more efficient to use a reference binary.

Closes #167.