### PR TITLE
Convert the port number to integer

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -33,7 +33,7 @@ defmodule Postgrex do
   ## Options
 
     * `:hostname` - Server hostname (default: PGHOST env variable, then localhost);
-    * `:port` - Server port (default: 5432);
+    * `:port` - Server port (default: PGPORT env variable, then 5432);
     * `:database` - Database (required);
     * `:username` - Username (default: PGUSER env variable, then USER env var);
     * `:password` - User password (default PGPASSWORD);

--- a/lib/postgrex/utils.ex
+++ b/lib/postgrex/utils.ex
@@ -52,15 +52,12 @@ defmodule Postgrex.Utils do
     |> Keyword.put_new(:username, System.get_env("PGUSER") || System.get_env("USER"))
     |> Keyword.put_new(:password, System.get_env("PGPASSWORD"))
     |> Keyword.put_new(:hostname, System.get_env("PGHOST") || "localhost")
-    |> Keyword.put_new(:port, parse_port_number(System.get_env("PGPORT")))
+    |> Keyword.update(:port, normalize_port(System.get_env("PGPORT")), &normalize_port/1)
     |> Enum.reject(fn {_k, v} -> is_nil(v) end)
   end
 
-  defp parse_port_number(nil), do: nil
-
-  defp parse_port_number(port) when is_binary(port) do
-    String.to_integer(port)
-  end
+  defp normalize_port(port) when is_binary(port), do: String.to_integer(port)
+  defp normalize_port(port), do: port
 
   @doc """
   List all default extensions.

--- a/test/login_test.exs
+++ b/test/login_test.exs
@@ -137,18 +137,21 @@ defmodule LoginTest do
     assert_receive {:ok, %Postgrex.Result{}}
   end
 
-  test "translates port to integer" do
-    opts = []
+  test "translates provided port number to integer" do
+    assert 123 == P.Utils.default_opts(port: "123")[:port]
+  end
+
+  test "defaults to PGPORT if no port number is provided" do
     previous_port = System.get_env("PGPORT")
     try do
       set_port_number("12345")
-      assert 12345 == P.Utils.default_opts(opts)[:port]
+      assert 12345 == P.Utils.default_opts([])[:port]
     after
       set_port_number(previous_port)
     end
   end
 
-  test "ignores pgport if non existent" do
+  test "ignores PGPORT if non existent" do
     opts = []
     previous_port = System.get_env("PGPORT")
     try do


### PR DESCRIPTION
In addition to the `PGPORT` fallback, now the given port number is also converted from string to integer.

Related: elixir-lang/ecto#544 and #171.