### PR TITLE
Add transaction mode options

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -302,7 +302,18 @@ defmodule Postgrex do
     `start_link/1`, see `DBConnection`;
     * `:mode` - Set to `:savepoint` to use savepoints instead of an SQL
     transaction, otherwise set to `:transaction` (default: `:transaction`);
-
+    * `:isolation` - Set the isolation level of the transaction (when the outter
+    transaction and `:mode` is `:transaction`), one of ``:serializable`,
+    `:repeatable_read`, `:read_comitted`, `:read_uncommitted`
+    or `nil`, where `nil` does not set the isolation level (default: `nil`);
+    * `:read_only` - Set whether the transaction is read only (when the outter
+    transaction and `:mode` is `:transaction`): `true` for read only, `false`
+    for read and write or `nil`, where `nil` does not set the read or write
+    access of the transaction (default: `nil`)
+    * `:deferrable` - Set whether the transaction is deferrable (when the outter
+    transaction and `:mode` is `:transaction`): `true` for deferrable,
+    `false` for not deferrable or `nil`, where `nil` does set whether the
+    transaction is deferrable (default: `nil`);
 
   The `:timeout` is for the duration of the transaction and all nested
   transactions and requests. This timeout overrides timeouts set by internal

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -103,6 +103,8 @@ defmodule Postgrex do
     `start_link/1`, see `DBConnection`
     * `:null` - The atom to use as a stand in for postgres' `NULL` in encoding
     and decoding;
+    * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
+    query on error, otherwise set to `:transaction` (default: `:transaction`);
 
   ## Examples
 
@@ -156,6 +158,8 @@ defmodule Postgrex do
     `start_link/1`, see `DBConnection`
     * `:null` - The atom to use as a stand in for postgres' `NULL` in encoding
     and decoding;
+    * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
+    prepare on error, otherwise set to `:transaction` (default: `:transaction`);
 
   ## Examples
 
@@ -199,6 +203,8 @@ defmodule Postgrex do
     decoding, (default: `fn x -> x end`);
     * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
+    execute on error, otherwise set to `:transaction` (default: `:transaction`);
 
   ## Examples
 
@@ -242,6 +248,8 @@ defmodule Postgrex do
     * `:timeout` - Close request timeout (default: `#{@timeout}`);
     * `:pool` - The pool module to use, must match that set on
     `start_link/1`, see `DBConnection`
+    * `:mode` - set to `:savepoint` to use a savepoint to rollback to before the
+    close on error, otherwise set to `:transaction` (default: `:transaction`);
 
   ## Examples
 

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -28,16 +28,7 @@ defmodule Postgrex.Protocol do
                              buffer: nil | binary | :active_once}
   @type notify :: ((binary, binary) -> any)
 
-  @reserved_prefix "POSTGREX_"
-  @reserved_queries ["BEGIN",
-                     "COMMIT",
-                     "ROLLBACK",
-                     "SAVEPOINT postgrex_savepoint",
-                     "RELEASE SAVEPOINT postgrex_savepoint",
-                     "ROLLBACK TO SAVEPOINT postgrex_savepoint",
-                     "SAVEPOINT postgrex_query",
-                     "RELEASE SAVEPOINT postgrex_query",
-                     "ROLLBACK TO SAVEPOINT postgrex_query"]
+  @reserved_prefix "POSTGREX "
 
   @spec connect(Keyword.t) ::
     {:ok, state} | {:error, Postgrex.Error.t}
@@ -225,8 +216,7 @@ defmodule Postgrex.Protocol do
   def handle_begin(opts, s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction ->
-        statement = "BEGIN"
-        handle_transaction(statement, :transaction, :begin, opts, s)
+        handle_transaction(begin_statement(opts), :transaction, :begin, opts, s)
       :savepoint   ->
         statement = "SAVEPOINT postgrex_savepoint"
         handle_savepoint([statement, :sync], :savepoint, opts, s)
@@ -542,7 +532,8 @@ defmodule Postgrex.Protocol do
     activate(s, buffer)
   end
   defp reserve_send(s, %{prepare: :named} = status, buffer) do
-    case msg_send(s, reserve_msgs() ++ [msg_sync()], buffer) do
+    %{parameters: parameters} = s
+    case msg_send(s, reserve_msgs(parameters) ++ [msg_sync()], buffer) do
       :ok ->
         reserve_recv(s, status, buffer)
       {:disconnect, _, _} = dis ->
@@ -550,9 +541,9 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp reserve_msgs() do
-    for statement <- @reserved_queries do
-      name = @reserved_prefix <> statement
+  defp reserve_msgs(parameters) do
+    for statement <- transaction_statements(parameters) do
+      name = [@reserved_prefix | statement]
       msg_parse(name: name, statement: statement, type_oids: [])
     end
   end
@@ -898,6 +889,69 @@ defmodule Postgrex.Protocol do
   end
 
   ## transaction
+
+  defp transaction_statements(parameters) do
+    begin_statements(parameters) ++
+    ["COMMIT",
+     "ROLLBACK",
+     "SAVEPOINT postgrex_savepoint",
+     "RELEASE SAVEPOINT postgrex_savepoint",
+     "ROLLBACK TO SAVEPOINT postgrex_savepoint",
+     "SAVEPOINT postgrex_query",
+     "RELEASE SAVEPOINT postgrex_query",
+     "ROLLBACK TO SAVEPOINT postgrex_query"]
+  end
+
+  defp begin_statements(parameters) do
+    isolations = [:serializable, :repeatable_read, :read_committed,
+                  :read_uncommitted, nil]
+    for deferrable <- defferable_modes(parameters),
+        isolation <- isolations,
+        read_only <- [true, false, nil] do
+          opts = [deferrable: deferrable, isolation: isolation,
+                  read_only: read_only]
+          begin_statement(opts)
+    end
+  end
+
+  defp defferable_modes(parameters) do
+    version = Postgrex.Utils.parse_version(parameters["server_version"])
+    if version >= {9, 1, 0} do
+      [true, false, nil]
+    else
+      [nil]
+    end
+  end
+
+  defp begin_statement(opts) do
+    ["BEGIN", isolation_mode(opts), read_mode(opts) | deferrable_mode(opts)]
+  end
+
+  defp isolation_mode(opts) do
+    case opts[:isolation] do
+      :serializable     -> " ISOLATION LEVEL SERIALIZABLE"
+      :repeatable_read  -> " ISOLATION LEVEL REPEATABLE READ"
+      :read_committed   -> " ISOLATION LEVEL READ COMMITTED"
+      :read_uncommitted -> " ISOLATION LEVEL READ UNCOMMITTED"
+      nil               -> ""
+    end
+  end
+
+  defp read_mode(opts) do
+    case opts[:read_only] do
+      true  -> " READ ONLY";
+      false -> " READ WRITE";
+      nil   -> ""
+    end
+  end
+
+  defp deferrable_mode(opts) do
+    case opts[:deferrable] do
+      true  -> " DEFERRABLE"
+      false -> " NOT DEFERRABLE"
+      nil   -> ""
+    end
+  end
 
   defp handle_transaction(name, next_postgres, cmd, opts, s) do
     %{connection_id: connection_id, buffer: buffer} = s

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -13,7 +13,8 @@ defmodule Postgrex.Protocol do
   @sock_opts [packet: :raw, mode: :binary, active: false]
 
   defstruct [sock: nil, connection_id: nil, types: nil, null: nil, timeout: nil,
-             parameters: %{}, queries: nil, postgres: :idle, buffer: nil]
+             parameters: %{}, queries: nil, postgres: :idle,
+             transactions: :naive, buffer: nil]
 
   @type state :: %__MODULE__{sock: {module, any},
                              connection_id: pos_integer,
@@ -22,7 +23,8 @@ defmodule Postgrex.Protocol do
                              timeout: timeout,
                              parameters: %{binary => binary} | reference,
                              queries: nil | :ets.tid,
-                             postgres: :idle | :transaction | :naive,
+                             postgres: :idle | :transaction | :failed,
+                             transactions: :strict | :naive,
                              buffer: nil | binary | :active_once}
   @type notify :: ((binary, binary) -> any)
 
@@ -49,10 +51,10 @@ defmodule Postgrex.Protocol do
     types?     = Keyword.fetch!(opts, :types)
     null       = opts[:null]
 
-    postgres =
+    transactions =
       case opts[:transactions] || :naive do
         :naive  -> :naive
-        :strict -> :idle
+        :strict -> :strict
       end
 
     prepare =
@@ -61,7 +63,8 @@ defmodule Postgrex.Protocol do
         :unnamed -> :unnamed
       end
 
-    s = %__MODULE__{timeout: timeout, postgres: postgres, null: null}
+    s = %__MODULE__{timeout: timeout, postgres: :idle,
+                    transactions: transactions, null: null}
 
     types_key = if types?, do: {host, port, Keyword.fetch!(opts, :database), decode_bin, custom}
     status = %{opts: opts, types_key: types_key, types_ref: nil,
@@ -97,7 +100,7 @@ defmodule Postgrex.Protocol do
 
   @spec checkout(state) ::
     {:ok, state} | {:disconnect, Postgrex.Error.t, state}
-  def checkout(%{postgres: :transaction} = s) do
+  def checkout(%{postgres: :transaction, transactions: :strict} = s) do
     sync_error(s, :transaction)
   end
   def checkout(%{buffer: :active_once} = s) do
@@ -109,7 +112,7 @@ defmodule Postgrex.Protocol do
 
   @spec checkin(state) ::
   {:ok, state} | {:disconnect, Postgrex.Error.t, state}
-  def checkin(%{postgres: :transaction} = s) do
+  def checkin(%{postgres: :transaction, transactions: :strict} = s) do
     sync_error(s, :transaction)
   end
   def checkin(%{buffer: buffer} = s) when is_binary(buffer) do
@@ -580,7 +583,7 @@ defmodule Postgrex.Protocol do
         complete(s, status, %Query{}, [], tag, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         err = Postgrex.Error.exception(postgres: fields)
-        sync_recv(s, status, nil, err, buffer)
+        sync_recv(s, status, err, buffer)
       {:ok, msg, buffer} ->
         simple_recv(handle_msg(s, status, msg), status, buffer)
       {:disconnect, _, _} = dis ->
@@ -595,12 +598,12 @@ defmodule Postgrex.Protocol do
     msgs =
       [msg_parse(name: name, statement: statement, type_oids: []),
        msg_describe(type: :statement, name: name),
-       msg_flush()]
+       msg_sync()]
     send_and_recv(s, status, query, buffer, msgs, &parse_recv/4)
   end
 
   defp describe_send(s, status, %Query{name: name} = query, buffer) do
-    msgs = [msg_describe(type: :statement, name: name), msg_flush()]
+    msgs = [msg_describe(type: :statement, name: name), msg_sync()]
     send_and_recv(s, status, query, buffer, msgs, &describe_recv/4)
   end
 
@@ -615,10 +618,11 @@ defmodule Postgrex.Protocol do
       {:ok, msg_error(fields: fields), buffer} when prepare == :parse_execute ->
         err =  Postgrex.Error.exception(postgres: fields)
         unnamed_query_delete(s, query)
-        sync_recv(s, status, query, err, buffer)
+        sync_recv(s, status, err, buffer)
       {:ok, msg_error(fields: fields), buffer} when prepare == :parse_describe ->
         unnamed_query_delete(s, query)
-        sync(s, status, Postgrex.Error.exception(postgres: fields), buffer)
+        err = Postgrex.Error.exception(postgres: fields)
+        sync_recv(s, status, err, buffer)
       {:ok, msg, buffer} ->
         parse_recv(handle_msg(s, status, msg), status, query, buffer)
       {:disconnect, _, _} = dis ->
@@ -629,20 +633,21 @@ defmodule Postgrex.Protocol do
   defp describe_recv(s, status, query, buffer) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_no_data(), buffer} ->
-        ok(s, %Query{query | types: s.types, null: s.null}, buffer)
+        query = %Query{query | types: s.types, null: s.null}
+        sync_recv(s, status, query, buffer)
       {:ok, msg_parameter_desc(type_oids: param_oids), buffer} ->
         describe_recv(s, status, %Query{query | encoders: param_oids}, buffer)
       {:ok, msg_row_desc(fields: fields), buffer} ->
         {col_oids, col_names} = columns(fields)
         query = %Query{query | types: s.types, null: s.null,
                                columns: col_names, decoders: col_oids}
-        ok(s, query, buffer)
+        sync_recv(s, status, query, buffer)
       {:ok, msg_too_many_parameters(len: len, max_len: max), buffer} ->
         msg = "postgresql protocol can not handle #{len} parameters, " <>
           "the maximum is #{max}"
         disconnect(s, Postgrex.Error.exception(message: msg), buffer)
       {:ok, msg_error(fields: fields), buffer} ->
-        sync(s, status, Postgrex.Error.exception(postgres: fields), buffer)
+        sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
         describe_recv(handle_msg(s, status, msg), status, query, buffer)
       {:disconnect, _, _} = dis ->
@@ -732,7 +737,7 @@ defmodule Postgrex.Protocol do
       end
       query_delete(s, query)
     end
-    sync_recv(s, status, query, err, buffer)
+    sync_recv(s, status, err, buffer)
   end
 
   defp execute_recv(s, status, query, buffer) do
@@ -742,10 +747,10 @@ defmodule Postgrex.Protocol do
       {:ok, msg_command_complete(tag: tag), buffer} ->
         complete(s, status, query, [], tag, buffer)
       {:ok, msg_empty_query(), buffer} ->
-        sync_recv(s, status, query, %Postgrex.Result{}, buffer)
+        sync_recv(s, status, %Postgrex.Result{}, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         err = Postgrex.Error.exception(postgres: fields)
-        sync_recv(s, status, query, err, buffer)
+        sync_recv(s, status, err, buffer)
       {:ok, msg, buffer} ->
         execute_recv(handle_msg(s, status, msg), status, query, buffer)
       {:disconnect, _, _} = dis ->
@@ -787,7 +792,7 @@ defmodule Postgrex.Protocol do
 
     result = %Postgrex.Result{command: command, num_rows: nrows || 0,
                               rows: rows, columns: cols, connection_id: connection_id}
-    sync_recv(s, status, query, result, buffer)
+    sync_recv(s, status, result, buffer)
   end
 
   defp decode_stream_state(:suspended), do: :suspended
@@ -797,13 +802,13 @@ defmodule Postgrex.Protocol do
   defp close(s, status, %Query{name: name} = query, result, buffer) do
     messages = [
       msg_close(type: :statement, name: name),
-      msg_flush()]
+      msg_sync()]
     close(s, status, query, buffer, result, messages)
   end
   defp close(s, status, %Stream{portal: portal} = stream, result, buffer) do
     messages = [
       msg_close(type: :portal, name: portal),
-      msg_flush()]
+      msg_sync()]
     close(s, status, stream, buffer, result, messages)
   end
   defp close(s, status, query, buffer, result, messages) do
@@ -814,13 +819,14 @@ defmodule Postgrex.Protocol do
         dis
     end
   end
+
   defp close_recv(s, status, query, result, buffer) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_close_complete(), buffer} ->
         query_delete(s, query)
-        ok(s, result, buffer)
+        sync_recv(s, status, result, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
-        ok(s, Postgrex.Error.exception(postgres: fields), buffer)
+        sync_recv(s, status, Postgrex.Error.exception(postgres: fields), buffer)
       {:ok, msg, buffer} ->
         close_recv(handle_msg(s, status, msg), status, query, result, buffer)
       {:disconnect, _, _} = dis ->
@@ -831,29 +837,25 @@ defmodule Postgrex.Protocol do
   ## sync
   defp sync(s, status, result, buffer) do
     case msg_send(s, msg_sync(), buffer) do
-      :ok                       -> sync_recv(s, status, nil, result, buffer)
+      :ok                       -> sync_recv(s, status, result, buffer)
       {:disconnect, _, _} = dis -> dis
     end
   end
 
   ## transaction
 
-  defp handle_transaction(name, postgres, cmd, opts, %{postgres: :naive} = s)
-  when postgres != :naive do
-    handle_transaction(name, :naive, cmd, opts, s)
-  end
-  defp handle_transaction(name, postgres, cmd, opts, s) do
+  defp handle_transaction(name, next_postgres, cmd, opts, s) do
     %{connection_id: connection_id, buffer: buffer} = s
     status = %{notify: notify(opts)}
     res = %Postgrex.Result{command: cmd, connection_id: connection_id}
-    transaction_send(%{s | buffer: nil}, status, name, postgres, res, buffer)
+    transaction_send(%{s | buffer: nil}, status, name, next_postgres, res, buffer)
   end
 
-  defp transaction_send(s, status, statement, postgres, res, buffer) do
+  defp transaction_send(s, status, statement, next_postgres, res, buffer) do
     msgs = transaction_msgs(s, [statement])
     case msg_send(s, msgs, buffer) do
       :ok ->
-        transaction_recv(s, status, postgres, res, buffer)
+        transaction_recv(s, status, next_postgres, res, buffer)
       {:disconnect, _, _} = dis ->
         dis
     end
@@ -875,29 +877,30 @@ defmodule Postgrex.Protocol do
      transaction_msgs(s, names)]
   end
 
-  defp transaction_recv(s, status, postgres, res, buffer) do
+  defp transaction_recv(s, status, next_postgres, res, buffer) do
+    %{transactions: transactions} = s
     case msg_recv(s, :infinity, buffer) do
-      {:ok, msg_ready(), buffer} when postgres == :naive ->
-        ok(s, res, buffer)
-      {:ok, msg_ready(status: ^postgres), buffer} ->
+      {:ok, msg_ready(status: postgres), buffer} when transactions == :naive ->
         ok(s, res, postgres, buffer)
+      {:ok, msg_ready(status: ^next_postgres), buffer} ->
+        ok(s, res, next_postgres, buffer)
       {:ok, msg_ready(status: postgres), buffer} ->
         sync_error(s, postgres, buffer)
       {:ok, msg_parse_complete(), buffer} ->
-        transaction_recv(s, status, postgres, res, buffer)
+        transaction_recv(s, status, next_postgres, res, buffer)
       {:ok, msg_bind_complete(), buffer} ->
-        transaction_recv(s, status, postgres, res, buffer)
+        transaction_recv(s, status, next_postgres, res, buffer)
       {:ok, msg_command_complete(), buffer} ->
-        transaction_recv(s, status, postgres, res, buffer)
-      {:ok, msg_error(fields: fields), buffer} when postgres == :naive ->
+        transaction_recv(s, status, next_postgres, res, buffer)
+      {:ok, msg_error(fields: fields), buffer} when transactions == :naive ->
         err = Postgrex.Error.exception(postgres: fields)
-        sync_recv(s, status, nil, err, buffer)
+        sync_recv(s, status, err, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         err = Postgrex.Error.exception(postgres: fields)
         disconnect(s, err, buffer)
       {:ok, msg, buffer} ->
         s = handle_msg(s, status, msg)
-        transaction_recv(s, status, postgres, res, buffer)
+        transaction_recv(s, status, next_postgres, res, buffer)
       {:disconnect, _, _} = dis ->
         dis
     end
@@ -920,7 +923,8 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp savepoint_recv(%{postgres: postgres} = s, status, res, buffer) do
+  defp savepoint_recv(s, status, res, buffer) do
+    %{postgres: postgres, transactions: transactions} = s
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_parse_complete(), buffer} ->
         savepoint_recv(s, status, res, buffer)
@@ -928,17 +932,20 @@ defmodule Postgrex.Protocol do
         savepoint_recv(s, status, res, buffer)
       {:ok, msg_command_complete(), buffer} ->
         savepoint_recv(s, status, res, buffer)
-      {:ok, msg_ready(status: :idle), buffer} when postgres == :transaction ->
+      {:ok, msg_ready(status: :idle), buffer}
+      when postgres == :transaction and transactions == :strict ->
         sync_error(s, :idle, buffer)
-      {:ok, msg_ready(status: :transaction), buffer} when postgres == :idle ->
+      {:ok, msg_ready(status: :transaction), buffer}
+      when postgres == :idle and transactions == :strict ->
         sync_error(s, :transaction, buffer)
-      {:ok, msg_ready(status: :failed), buffer} when postgres == :idle ->
+      {:ok, msg_ready(status: :failed), buffer}
+      when postgres == :idle and transactions == :strict ->
         sync_error(s, :failed, buffer)
-      {:ok, msg_ready(), buffer} ->
-        ok(s, res, buffer)
+      {:ok, msg_ready(status: postgres), buffer} ->
+        ok(s, res, postgres, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         err = Postgrex.Error.exception(postgres: fields)
-        sync_recv(s, status, nil, err, buffer)
+        sync_recv(s, status, err, buffer)
       {:ok, msg, buffer} ->
         s = handle_msg(s, status, msg)
         savepoint_recv(s, status, res, buffer)
@@ -1124,25 +1131,22 @@ defmodule Postgrex.Protocol do
     s
   end
 
-  defp ok(s, %Postgrex.Result{} = res, buffer) do
-    {:ok, res, %{s | buffer: buffer}}
-  end
-  defp ok(s, %Postgrex.Query{} = query, buffer) do
-    {:ok, query, %{s | buffer: buffer}}
-   end
-  defp ok(%{connection_id: connection_id} = s, %Postgrex.Error{} = err, buffer) do
-    {:error, %{err | connection_id: connection_id}, %{s | buffer: buffer}}
-  end
-  defp ok(s, :active_once, buffer) do
-    activate(s, buffer)
-  end
-  defp ok(s, nil, buffer) do
-    {:ok, %{s | buffer: buffer}}
-  end
-
-  defp ok(s, %Postgrex.Result{} = res, postgres, buffer)
-  when postgres in [:idle, :transaction] do
+  defp ok(s, %Postgrex.Result{} = res, postgres, buffer) do
     {:ok, res, %{s | postgres: postgres, buffer: buffer}}
+  end
+  defp ok(s, %Postgrex.Query{} = query, postgres, buffer) do
+    {:ok, query, %{s | postgres: postgres, buffer: buffer}}
+   end
+  defp ok(s, %Postgrex.Error{} = err, postgres, buffer) do
+    %{connection_id: connection_id} = s
+    err = %{err | connection_id: connection_id}
+    {:error, err, %{s | postgres: postgres, buffer: buffer}}
+  end
+  defp ok(s, :active_once, postgres, buffer) do
+    activate(%{s | postgres: postgres}, buffer)
+  end
+  defp ok(s, nil, postgres, buffer) do
+    {:ok, %{s | postgres: postgres, buffer: buffer}}
   end
 
   defp disconnect(s, tag, action, reason, buffer) do
@@ -1160,21 +1164,24 @@ defmodule Postgrex.Protocol do
   end
 
   # Query has completed so ok to use state timeout as message should either be
-  # buffer or in flight. sync_recv/5 used by simple queries so can't use
+  # buffer or in flight. sync_recv/4 used by simple queries so can't use
   # :infinity.
-  defp sync_recv(s, status, query, result, buffer) do
-    %{postgres: postgres, timeout: timeout} = s
+  defp sync_recv(s, status, result, buffer) do
+    %{postgres: postgres, transactions: transactions, timeout: timeout} = s
     case msg_recv(s, timeout, buffer) do
-      {:ok, msg_ready(status: :idle), buffer} when postgres == :transaction ->
+      {:ok, msg_ready(status: :idle), buffer}
+      when postgres == :transaction and transactions == :strict ->
         sync_error(s, :idle, buffer)
-      {:ok, msg_ready(status: :transaction), buffer} when postgres == :idle ->
+      {:ok, msg_ready(status: :transaction), buffer}
+      when postgres == :idle and transactions == :strict ->
         sync_error(s, :transaction, buffer)
-      {:ok, msg_ready(status: :failed), buffer} when postgres == :idle ->
+      {:ok, msg_ready(status: :failed), buffer}
+      when postgres == :idle and transactions == :strict ->
         sync_error(s, :failed, buffer)
-      {:ok, msg_ready(), buffer} ->
-        ok(s, result, buffer)
+      {:ok, msg_ready(status: postgres), buffer} ->
+        ok(s, result, postgres, buffer)
       {:ok, msg, buffer} ->
-        sync_recv(handle_msg(s, status, msg), status, query, result, buffer)
+        sync_recv(handle_msg(s, status, msg), status, result, buffer)
       {:disconnect, _, _} = dis ->
         dis
     end

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -672,10 +672,10 @@ defmodule QueryTest do
 
   test "raise when trying to prepare or close reserved query", context do
     assert_raise ArgumentError, ~r/uses reserved name/,
-      fn -> prepare("POSTGREX_BEGIN", "COMMIT") end
+      fn -> prepare("POSTGREX BEGIN", "COMMIT") end
 
     query = prepare("BEGIN", "BEGIN")
-    query = %Postgrex.Query{query | name: "POSTGREX_BEGIN"}
+    query = %Postgrex.Query{query | name: "POSTGREX BEGIN"}
 
     assert_raise ArgumentError, ~r/uses reserved name/, fn -> close(query) end
   end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -389,4 +389,29 @@ defmodule TransactionTest do
     assert [[42]] = query("SELECT 42", [])
     assert :ok = query("ROLLBACK", [])
   end
+
+  @tag mode: :transaction
+  test "read only transaction mode", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}}} =
+       P.query(conn, "insert into uniques values (1), (1);", [])
+     assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
+       P.query(conn, "SELECT 42", [])
+      :hi
+    end, [read_only: true]) == {:ok, :hi}
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  @tag prepare: :unnamed
+  test "read only transaction mode with unnamed queries", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :read_only_sql_transaction}}} =
+       P.query(conn, "insert into uniques values (1), (1);", [])
+     assert {:error, %Postgrex.Error{postgres: %{code: :in_failed_sql_transaction}}} =
+       P.query(conn, "SELECT 42", [])
+      :hi
+    end, [read_only: true]) == {:ok, :hi}
+    assert [[42]] = query("SELECT 42", [])
+  end
 end

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -175,4 +175,190 @@ defmodule TransactionTest do
       query("RELEASE SAVEPOINT postgrex_savepoint", [])
     assert :ok = query("ROLLBACK", [])
   end
+
+  @tag mode: :transaction
+  test "transaction works after failure in savepoint query parsing state", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+      P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  test "savepoint query releases savepoint in transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} =
+        P.query(conn, "SELECT 42", [], [mode: :savepoint])
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}}} =
+        P.query(conn, "RELEASE SAVEPOINT postgrex_query", [])
+      P.rollback(conn, :oops)
+    end) == {:error, :oops}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  test "savepoint query rolls back and releases savepoint in transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}}} =
+        P.query(conn, "RELEASE SAVEPOINT postgrex_query", [])
+      P.rollback(conn, :oops)
+    end) == {:error, :oops}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  @tag prepare: :unnamed
+  test "unnamed savepoint query releases savepoint in transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} =
+        P.query(conn, "SELECT 42", [], [mode: :savepoint])
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}}} =
+        P.query(conn, "RELEASE SAVEPOINT postgrex_query", [])
+      P.rollback(conn, :oops)
+    end) == {:error, :oops}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  test "unnamed savepoint query rolls back and releases savepoint in transaction", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_savepoint_specification}}} =
+        P.query(conn, "RELEASE SAVEPOINT postgrex_query", [])
+      P.rollback(conn, :oops)
+    end) == {:error, :oops}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  test "transaction works after failure in savepoint query binding state", context do
+    assert transaction(fn(conn) ->
+      statement = "insert into uniques values (CAST($1::text AS int))"
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_text_representation}}} =
+        P.query(conn, statement, ["invalid"], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  test "transaction works after failure in savepoint query executing state", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  @tag prepare: :unnamed
+  test "transaction works after failure in unammed savepoint query parsing state", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+      P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  @tag prepare: :unnamed
+  test "transaction works after failure in unnamed savepoint query binding state", context do
+    assert transaction(fn(conn) ->
+      statement = "insert into uniques values (CAST($1::text AS int))"
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_text_representation}}} =
+        P.query(conn, statement, ["invalid"], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :transaction
+  @tag prepare: :unnamed
+  test "transaction works after failure in unnamed savepoint query executing state", context do
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+  end
+
+  @tag mode: :savepoint
+  test "savepoint transaction works after failure in savepoint query parsing state", context do
+    assert :ok = query("BEGIN", [])
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+      P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+    assert :ok = query("ROLLBACK", [])
+  end
+
+  @tag mode: :savepoint
+  test "savepoint transaction works after failure in savepoint query binding state", context do
+    assert :ok = query("BEGIN", [])
+    assert transaction(fn(conn) ->
+      statement = "insert into uniques values (CAST($1::text AS int))"
+      assert {:error, %Postgrex.Error{postgres: %{code: :invalid_text_representation}}} =
+        P.query(conn, statement, ["invalid"], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+    assert :ok = query("ROLLBACK", [])
+  end
+
+  @tag mode: :savepoint
+  test "savepoint transaction works after failure in savepoint query executing state", context do
+    assert :ok = query("BEGIN", [])
+    assert transaction(fn(conn) ->
+      assert {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} =
+        P.query(conn, "insert into uniques values (1), (1);", [], [mode: :savepoint])
+
+      assert {:ok, %Postgrex.Result{rows: [[42]]}} = P.query(conn, "SELECT 42", [])
+      :hi
+    end) == {:ok, :hi}
+
+    assert [[42]] = query("SELECT 42", [])
+    assert :ok = query("ROLLBACK", [])
+  end
 end


### PR DESCRIPTION
When beginning the outter transaction allows setting isolation level, read only and deferrable using prepared named or unnamed queries. Uses `nil` not to set a mode to use session defaults.

Prepares fix for: https://github.com/elixir-lang/ecto/issues/1460

Based on #198 to prevent conflicts and awaiting its merge.