### PR TITLE
Receive packets greater than 64MB

### DIFF
--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -11,6 +11,7 @@ defmodule Postgrex.Protocol do
 
   @timeout 5000
   @sock_opts [packet: :raw, mode: :binary, active: false]
+  @max_packet 64 * 1024 * 1024 # max raw receive length
 
   defstruct [sock: nil, connection_id: nil, types: nil, null: nil, timeout: nil,
              parameters: %{}, queries: nil, postgres: :idle,
@@ -1179,11 +1180,15 @@ defmodule Postgrex.Protocol do
   end
 
   defp msg_recv(%{sock: {mod, sock}} = s, timeout, buffer, more) do
-    case mod.recv(sock, more, timeout) do
-      {:ok, data} ->
+    case mod.recv(sock, min(more, @max_packet), timeout) do
+      {:ok, data} when byte_size(data) < more ->
+        msg_recv(s, timeout, [buffer | data], more - byte_size(data))
+      {:ok, data} when is_binary(buffer) ->
         msg_recv(s, timeout, buffer <> data)
+      {:ok, data} when is_list(buffer) ->
+        msg_recv(s, timeout, IO.iodata_to_binary([buffer | data]))
       {:error, reason} ->
-        disconnect(s, tag(mod), "recv", reason, buffer)
+        disconnect(s, tag(mod), "recv", reason, IO.iodata_to_binary(buffer))
     end
   end
 

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -730,4 +730,11 @@ defmodule QueryTest do
       assert_receive {:EXIT, ^pid, {:shutdown, %Postgrex.Error{}}}
     end
   end
+
+  test "receive packet with remainder greater than 64MB", context do
+    # to ensure remainder is more than 64MB use 64MBx2+1
+    big_binary = :binary.copy(<<1>>, 128*1024*1024+1)
+    assert [[binary]] = query("SELECT $1::bytea;", [big_binary])
+    assert byte_size(binary) == 128 * 1024 * 1024 + 1
+  end
 end


### PR DESCRIPTION
Closes #185.

It appears there is a built in limit to how much can be received and this is constant throughout multiple OS. People report 16MB, 32MB and 64MB as time progresses.

http://erlang.org/pipermail/erlang-questions/2006-September/022909.html
https://github.com/rabbitmq/rabbitmq-erlang-client/blob/591ddb8abce27e9737de3d373b7da40cc2c88453/src/amqp_network_connection.erl#L239
https://github.com/exxeleron/qErlang/blob/fbca1ba1f1234c3f9aef1f9a13d0234b70e19709/src/qErlang.erl#L137

I am awaiting a reply to check 64MB is a hard limit or how it is configured.