### PR TITLE
Add support for COPY TO STDOUT and COPY FROM STDIN

### DIFF
--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -116,6 +116,8 @@ defmodule Postgrex do
 
       Postgrex.query(conn, "SELECT id FROM posts WHERE title like $1", ["%my%"])
 
+      Postgrex.query(conn, "COPY posts TO STDOUT", [])
+
   """
   @spec query(conn, iodata, list, Keyword.t) :: {:ok, Postgrex.Result.t} | {:error, Postgrex.Error.t}
   def query(conn, statement, params, opts \\ []) do
@@ -124,6 +126,8 @@ defmodule Postgrex do
       {:ok, _, result} ->
         {:ok, result}
       {:error, %ArgumentError{} = err} ->
+        raise err
+      {:error, %RuntimeError{} = err} ->
         raise err
       {:error, _} = error ->
         error
@@ -170,6 +174,8 @@ defmodule Postgrex do
     query = %Query{name: name, statement: statement}
     case DBConnection.prepare(conn, query, defaults(opts)) do
       {:error, %ArgumentError{} = err} ->
+        raise err
+      {:error, %RuntimeError{} = err} ->
         raise err
       other ->
         other
@@ -220,6 +226,8 @@ defmodule Postgrex do
     case DBConnection.execute(conn, query, params, defaults(opts)) do
       {:error, %ArgumentError{} = err} ->
         raise err
+      {:error, %RuntimeError{} = err} ->
+        raise err
       other ->
         other
     end
@@ -263,6 +271,10 @@ defmodule Postgrex do
         :ok
       {:error, %ArgumentError{} = err} ->
         raise err
+      {:error, %RuntimeError{} = err} ->
+        raise err
+      {:error, _} = error ->
+        error
     end
   end
 
@@ -365,10 +377,13 @@ defmodule Postgrex do
   Returns a stream for a prepared query on a connection.
 
   Stream consumes memory in chunks of at most `max_rows` rows (see Options).
-
   This is useful for processing _large_ datasets.
 
-  A stream must be wrapped in a transaction.
+  A stream must be wrapped in a transaction and may be used as an `Enumerable`.
+
+  When used as an `Enumerable` with a `COPY .. TO STDOUT` SQL query no other
+  queries or streams can be interspersed until the copy has finished. Otherwise
+  it is possible to intersperse enumerable streams and queries.
 
   ### Options
 
@@ -377,6 +392,14 @@ defmodule Postgrex do
     decoding, (default: `fn x -> x end`);
     * `:mode` - set to `:savepoint` to use a savepoint to rollback to before an
     execute on error, otherwise set to `:transaction` (default: `:transaction`);
+
+  ## Examples
+
+      Postgrex.transaction(pid, fn(conn) ->
+        query = Postgrex.prepare!(conn, "COPY posts TO STDOUT")
+        stream = Postgrex.stream(conn, query, [])
+        Enum.into(stream, File.stream!("posts"))
+      end)
   """
   @spec stream(DBConnection.t, Postgrex.Query.t, list, Keyword.t) :: Postgrex.Stream.t
   def stream(%DBConnection{} = conn, query, params, options \\ [])  do

--- a/lib/postgrex.ex
+++ b/lib/postgrex.ex
@@ -379,11 +379,18 @@ defmodule Postgrex do
   Stream consumes memory in chunks of at most `max_rows` rows (see Options).
   This is useful for processing _large_ datasets.
 
-  A stream must be wrapped in a transaction and may be used as an `Enumerable`.
+  A stream must be wrapped in a transaction and may be used as an `Enumerable`
+  or a `Collectable`.
 
   When used as an `Enumerable` with a `COPY .. TO STDOUT` SQL query no other
   queries or streams can be interspersed until the copy has finished. Otherwise
   it is possible to intersperse enumerable streams and queries.
+
+  When used as a `Collectable` it is assumed that the enumerable inserting into
+  the stream is inserting `iodata()` as part of a `COPY .. FROM STDIN` SQL
+  query. The query will be repeated for each piece of data inserted into the
+  stream. Therefore when used with other SQL queries the query is executed for
+  each item in the enumerable but the data and result are ignored.
 
   ### Options
 
@@ -397,8 +404,12 @@ defmodule Postgrex do
 
       Postgrex.transaction(pid, fn(conn) ->
         query = Postgrex.prepare!(conn, "COPY posts TO STDOUT")
-        stream = Postgrex.stream(conn, query, [])
-        Enum.into(stream, File.stream!("posts"))
+        Enum.into(Postgrex.stream(conn, query, []), File.stream!("posts"))
+      end)
+
+      Postgrex.transaction(pid, fn(conn) ->
+        query = Postgrex.prepare!(conn, "COPY posts FROM STDIN")
+        Enum.into(File.stream!("posts"), Postgrex.stream(conn, query, []))
       end)
   """
   @spec stream(DBConnection.t, Postgrex.Query.t, list, Keyword.t) :: Postgrex.Stream.t

--- a/lib/postgrex/messages.ex
+++ b/lib/postgrex/messages.ex
@@ -308,6 +308,16 @@ defmodule Postgrex.Messages do
     {nil, <<1234 :: int16, 5679 :: int16>>}
   end
 
+  # copy_data
+  defp encode(msg_copy_data(data: data)) do
+    {?d, data}
+  end
+
+  # copy_done
+  defp encode(msg_copy_done()) do
+    {?c, ""}
+  end
+
   # copy_fail
   defp encode(msg_copy_fail(message: msg)) do
     {?f, [msg, 0]}

--- a/lib/postgrex/protocol.ex
+++ b/lib/postgrex/protocol.ex
@@ -127,8 +127,11 @@ defmodule Postgrex.Protocol do
 
   @spec handle_prepare(Postgrex.Query.t, Keyword.t, state) ::
     {:ok, Postgrex.Query.t, state} |
-    {:error, ArgumentError.t, state} |
+    {:error, ArgumentError.t | RuntimeError.t, state} |
     {:error | :disconnect, Postgrex.Query.t, state}
+  def handle_prepare(query, _, %{postgres: {_, _}} = s) do
+    lock_error(s, :prepare, query)
+  end
   def handle_prepare(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
   end
@@ -169,7 +172,7 @@ defmodule Postgrex.Protocol do
   @spec handle_execute(Postgrex.Stream.t | Postgrex.Query.t, list, Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
     {:error, ArgumentError.t, state} |
-    {:error | :disconnect, Postgrex.Error.t, state}
+    {:error | :disconnect, RuntimeError.t, Postgrex.Error.t, state}
   def handle_execute(req, params, opts, s) do
     %{buffer: buffer} = s
     status = %{notify: notify(opts), mode: mode(opts)}
@@ -178,15 +181,17 @@ defmodule Postgrex.Protocol do
     case action do
       {:bind_execute, query} ->
         bind_execute_send(s, status, query, params, buffer)
-      {:bind_execute, stream, query} ->
-        bind_execute_send(s, status, stream, query, params, buffer)
+      {:bind, stream, query} ->
+        bind_send(s, status, stream, query, params, buffer)
       {:parse_execute, query} ->
         parse_execute_send(s, status, query, params, buffer)
-      {:parse_execute, stream, query} ->
-        parse_execute_send(s, status, stream, query, params, buffer)
+      {:parse_bind, stream, query} ->
+        parse_bind_send(s, status, stream, query, params, buffer)
       {:execute, stream} ->
         execute_send(s, status, stream, buffer)
-      {:error, _, _} = error ->
+      {:copy_out, stream} ->
+        copy_out(s, status, stream, buffer)
+      {kind, _, _} = error when kind in [:error, :disconnect] ->
         error
     end
   end
@@ -194,7 +199,16 @@ defmodule Postgrex.Protocol do
   @spec handle_close(Postgrex.Query.t | Postgrex.Stream.t, Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
     {:error, ArgumentError.t, state} |
-    {:error | :disconnect, Postgrex.Error.t, state}
+    {:error | :disconnect, RuntimeError.t | Postgrex.Error.t, state}
+  def handle_close(%Stream{ref: ref} = stream, _, %{postgres: {_, ref}} = s) do
+    msg = "postgresql protocol can not halt copying from database for " <>
+      inspect(stream)
+    err = RuntimeError.exception(message: msg)
+    {:disconnect, err, s}
+  end
+  def handle_close(query, _, %{postgres: {_, _}} = s) do
+    lock_error(s, :close, query)
+  end
   def handle_close(%Query{name: @reserved_prefix <> _} = query, _, s) do
     reserved_error(query, s)
   end
@@ -207,7 +221,11 @@ defmodule Postgrex.Protocol do
 
   @spec handle_begin(Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
+    {:disconnect, RuntimeError.t, state} |
     {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_begin(_, %{postgres: {_, _}} = s) do
+    lock_error(s, :begin)
+  end
   def handle_begin(opts, s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction ->
@@ -221,7 +239,11 @@ defmodule Postgrex.Protocol do
 
   @spec handle_commit(Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
+    {:disconnect, RuntimeError.t, state} |
     {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_commit(_, %{postgres: {_, _}} = s) do
+    lock_error(s, :commit)
+  end
   def handle_commit(opts, %{postgres: postgres} = s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction ->
@@ -237,7 +259,11 @@ defmodule Postgrex.Protocol do
 
   @spec handle_rollback(Keyword.t, state) ::
     {:ok, Postgrex.Result.t, state} |
+    {:disconnect, RuntimeError.t, state} |
     {:error | :disconnect, Postgrex.Error.t, state}
+  def handle_rollback(_, %{postgres: {_, _}} = s) do
+    lock_error(s, :rollback)
+  end
   def handle_rollback(opts, s) do
     case Keyword.get(opts, :mode, :transaction) do
       :transaction ->
@@ -650,6 +676,21 @@ defmodule Postgrex.Protocol do
     {:error, ArgumentError.exception(msg), s}
   end
 
+  defp lock_error(s, fun) do
+    msg = "connection is locked copying from the database and " <>
+      "can not #{fun} transaction"
+    {:disconnect, RuntimeError.exception(msg), s}
+  end
+
+  defp lock_error(s, fun, query) do
+    msg = "connection is locked copying from the database and " <>
+      "can not #{fun} #{inspect query}"
+    {:error, RuntimeError.exception(msg), s}
+  end
+
+  defp execute(%{postgres: {_, _ref}} = s, %Query{} = query) do
+    lock_error(s, :execute, query)
+  end
   defp execute(s, %Query{name: @reserved_prefix <> _} = query) do
     reserved_error(query, s)
   end
@@ -669,7 +710,19 @@ defmodule Postgrex.Protocol do
   defp execute(s, %Query{} = query) do
     query_error(s, "query #{inspect query} has invalid types for the connection")
   end
-  defp execute(s, %Stream{query: query, state: :suspended} = stream) do
+  defp execute(%{postgres: {_, ref}}, %Stream{state: :copy_out, ref: ref} = stream) do
+    {:copy_out, stream}
+  end
+  defp execute(s, %Stream{state: :copy_out} = stream) do
+    msg = "connection lost lock for copying from the database and " <>
+      "can not execute #{inspect stream}"
+    {:disconnect, RuntimeError.exception(msg), s}
+  end
+  defp execute(%{postgres: {_, _ref}} = s, %Stream{} = stream) do
+    lock_error(s, :execute, stream)
+  end
+  defp execute(s, %Stream{query: query, state: state} = stream)
+      when state in [:out, :suspended] do
     case execute(s, query) do
       {execute, _} when execute in [:bind_execute, :parse_execute] ->
         {:execute, stream}
@@ -677,12 +730,12 @@ defmodule Postgrex.Protocol do
         error
     end
   end
-  defp execute(s, %Stream{query: query, state: nil} = stream) do
+  defp execute(s, %Stream{query: query, state: :bind} = stream) do
     case execute(s, query) do
       {:bind_execute, query} ->
-        {:bind_execute, %Stream{stream | query: query}, query}
+        {:bind, %Stream{stream | query: query}, query}
       {:parse_execute, query} ->
-        {:parse_execute, %Stream{stream | query: query}, query}
+        {:parse_bind, %Stream{stream | query: query}, query}
       {:error, _, _} = error ->
         error
     end
@@ -694,13 +747,16 @@ defmodule Postgrex.Protocol do
     send_and_recv(s, status, stream, buffer, messages, &execute_recv/4)
   end
 
-  defp bind_execute_send(s, status, stream, query, params, buffer) do
-    %Stream{portal: portal, max_rows: max_rows} = stream
+  defp bind_send(s, status, stream, query, params, buffer) do
+    %{connection_id: connection_id} = s
+    res = %Postgrex.Result{command: :bind, connection_id: connection_id}
+    %Stream{portal: portal} = stream
     %Query{param_formats: pfs, result_formats: rfs, name: name} = query
     messages = [
-      msg_bind(name_port: portal, name_stat: name, param_formats: pfs, params: params, result_formats: rfs),
-      msg_execute(name_port: portal, max_rows: max_rows)]
-    send_and_recv(s, status, stream, buffer, messages, &bind_recv/4)
+      msg_bind(name_port: portal, name_stat: name, param_formats: pfs, params: params, result_formats: rfs)]
+    sync_recv = &sync_recv/4
+    recv = &bind_recv(&1, &2, &3, &4, sync_recv)
+    send_and_recv(s, status, res, buffer, messages, recv)
   end
 
   defp bind_execute_send(s, status, query, params, buffer) do
@@ -711,14 +767,20 @@ defmodule Postgrex.Protocol do
     send_and_recv(s, status, query, buffer, msgs, &bind_recv/4)
   end
 
-  defp parse_execute_send(s, status, stream, query, params, buffer) do
-    %Stream{portal: portal, max_rows: max_rows} = stream
+  defp parse_bind_send(s, status, stream, query, params, buffer) do
+    %{connection_id: connection_id} = s
+    res = %Postgrex.Result{command: :bind, connection_id: connection_id}
+    %Stream{portal: portal} = stream
     %Query{param_formats: pfs, result_formats: rfs, name: name, statement: statement} = query
     messages = [
       msg_parse(name: name, statement: statement, type_oids: []),
-      msg_bind(name_port: portal, name_stat: name, param_formats: pfs, params: params, result_formats: rfs),
-      msg_execute(name_port: portal, max_rows: max_rows)]
-    send_and_recv(s, status, stream, buffer, messages, &parse_recv/4)
+      msg_bind(name_port: portal, name_stat: name, param_formats: pfs, params: params, result_formats: rfs)]
+    sync_recv = &sync_recv/4
+    bind_recv = fn(s, status, _query, buffer) ->
+      bind_recv(s, status, res, buffer, sync_recv)
+    end
+    parse_recv = &parse_recv(&1, &2, &3, &4, bind_recv)
+    send_and_recv(s, status, query, buffer, messages, parse_recv)
   end
 
   defp parse_execute_send(s, status, query, params, buffer) do
@@ -801,10 +863,10 @@ defmodule Postgrex.Protocol do
     end
   end
 
-  defp bind_recv(s, status, query, buffer) do
+  defp bind_recv(s, status, query, buffer, recv \\ &execute_recv/4) do
     case msg_recv(s, :infinity, buffer) do
       {:ok, msg_bind_complete(), buffer} ->
-        execute_recv(s, status, query, buffer)
+        recv.(s, status, query, buffer)
       {:ok, msg_error(fields: fields), buffer} ->
         bind_error(s, status, query, fields, buffer)
       {:ok, msg, buffer} ->
@@ -841,7 +903,7 @@ defmodule Postgrex.Protocol do
         err = ArgumentError.exception(msg)
         copy_fail_send(s, status, err, buffer)
       {:ok, msg_copy_out_response(), buffer} ->
-        copy_out_disconnect(s, query, buffer)
+        copy_out(s, status, query, buffer)
       {:ok, msg_copy_both_response(), buffer} ->
         copy_out_disconnect(s, query, buffer)
       {:ok, msg, buffer} ->
@@ -875,7 +937,7 @@ defmodule Postgrex.Protocol do
       if is_nil(nrows) and command == :select, do: length(rows), else: nrows
 
     rows =
-      if is_nil(cols) and rows == [], do: nil, else: rows
+      if is_nil(cols) and rows == [] and command != :copy, do: nil, else: rows
 
     result = %Postgrex.Result{command: command, num_rows: nrows || 0,
                               rows: rows, columns: cols, connection_id: connection_id}
@@ -909,6 +971,57 @@ defmodule Postgrex.Protocol do
         do_sync_recv(s, status, err, buffer)
       {:ok, msg, buffer} ->
         copy_fail_recv(handle_msg(s, status, msg), status, err, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
+    end
+  end
+
+  defp copy_out(s, status, %Query{} = query, buffer) do
+    copy_out_recv(s, status, query, :infinity, [], 0, buffer)
+  end
+  defp copy_out(s, status, stream, buffer) do
+    %Stream{max_rows: max_rows} = stream
+    max_rows = if max_rows == 0, do: :infinity, else: max_rows
+    copy_out_recv(s, status, stream, max_rows, [], 0, buffer)
+  end
+
+  defp copy_out_recv(s, _, stream, max_rows, acc, max_rows, buffer) do
+    %Stream{ref: ref} = stream
+    %{postgres: postgres, connection_id: connection_id} = s
+    result = %Postgrex.Result{command: :copy_stream, num_rows: max_rows,
+      rows: acc, columns: nil, connection_id: connection_id}
+    ok(s, result, {postgres, ref}, buffer)
+  end
+  defp copy_out_recv(s, status, query, max_rows, acc, nrows, buffer) do
+     case msg_recv(s, :infinity, buffer) do
+      {:ok, msg_copy_data(data: data), buffer} ->
+        copy_out_recv(s, status, query, max_rows, [data | acc], nrows+1, buffer)
+      {:ok, msg_copy_done(), buffer} ->
+        copy_out_done(s, status, acc, nrows, buffer)
+      {:ok, msg_error(fields: fields), buffer} ->
+        err = Postgrex.Error.exception(postgres: fields)
+        sync_recv(s, status, err, buffer)
+      {:ok, msg, buffer} ->
+        s = handle_msg(s, status, msg)
+        copy_out_recv(s, status, query, max_rows, acc, nrows, buffer)
+      {:disconnect, _, _} = dis ->
+        dis
+    end
+  end
+
+  defp copy_out_done(s, status, acc, nrows, buffer) do
+    case msg_recv(s, :infinity, buffer) do
+      {:ok, msg_command_complete(), buffer} ->
+        %{connection_id: connection_id} = s
+        result = %Postgrex.Result{command: :copy, num_rows: nrows,
+          rows: acc, columns: nil, connection_id: connection_id}
+        sync_recv(s, status, result, buffer)
+      {:ok, msg_error(fields: fields), buffer} ->
+        err = Postgrex.Error.exception(postgres: fields)
+        sync_recv(s, status, err, buffer)
+      {:ok, msg, buffer} ->
+        s = handle_msg(s, status, msg)
+        copy_out_done(s, status, acc, nrows, buffer)
       {:disconnect, _, _} = dis ->
         dis
     end

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -1,11 +1,10 @@
 defmodule Postgrex.Stream do
-  defstruct [:conn, :options, :params, :portal, :query, :state, :result, max_rows: 500]
+  defstruct [:conn, :options, :params, :portal, :query, :ref, state: :bind, max_rows: 500]
 end
 
 defimpl Enumerable, for: Postgrex.Stream do
   def reduce(stream, acc, fun) do
-    start = fn -> maybe_generate_portal(stream) end
-    Stream.resource(start, &next/1, &close/1).(acc, fun)
+    Stream.resource(fn() -> start(stream) end, &next/1, &close/1).(acc, fun)
   end
 
   def member?(_, _) do
@@ -16,6 +15,13 @@ defimpl Enumerable, for: Postgrex.Stream do
     {:error, __MODULE__}
   end
 
+  defp start(stream) do
+    %Postgrex.Stream{conn: conn, params: params, options: options} = stream
+    stream = maybe_generate_portal(stream)
+    _ = Postgrex.execute!(conn, stream, params, options)
+    %Postgrex.Stream{stream | state: :out}
+  end
+
   defp next(%Postgrex.Stream{state: :done} = stream) do
     {:halt, stream}
   end
@@ -23,14 +29,18 @@ defimpl Enumerable, for: Postgrex.Stream do
     %Postgrex.Stream{conn: conn, params: params, options: options,
                      state: state} = stream
     case Postgrex.execute!(conn, stream, params, options) do
-      %Postgrex.Result{command: :stream} = result when state == nil ->
+      %Postgrex.Result{command: :stream} = result when state == :out ->
         {[result], %Postgrex.Stream{stream | state: :suspended}}
       %Postgrex.Result{command: :stream} = result when state == :suspended ->
         {[result], stream}
-      %Postgrex.Result{rows: []} ->
-        {:halt, %Postgrex.Stream{stream | state: :done}}
-      %Postgrex.Result{} = result ->
+      %Postgrex.Result{command: :copy_stream} = result when state == :out ->
+        {[result], %Postgrex.Stream{stream | state: :copy_out}}
+      %Postgrex.Result{command: :copy_stream} = result when state == :copy_out ->
+        {[result], stream}
+      %Postgrex.Result{rows: [_|_]} = result ->
         {[result], %Postgrex.Stream{stream | state: :done}}
+      %Postgrex.Result{} ->
+        {:halt, %Postgrex.Stream{stream | state: :done}}
     end
   end
 
@@ -38,10 +48,13 @@ defimpl Enumerable, for: Postgrex.Stream do
     DBConnection.close(conn, stream, options)
   end
 
-  defp maybe_generate_portal(%Postgrex.Stream{portal: nil} = stream),
-    do: %Postgrex.Stream{stream | portal: :erlang.ref_to_list(make_ref())}
-  defp maybe_generate_portal(stream),
-    do: stream
+  defp maybe_generate_portal(%Postgrex.Stream{portal: nil} = stream) do
+    ref = make_ref()
+    %Postgrex.Stream{stream | portal: inspect(ref), ref: ref}
+  end
+  defp maybe_generate_portal(stream) do
+    %Postgrex.Stream{stream | ref: make_ref()}
+  end
 end
 
 defimpl DBConnection.Query, for: Postgrex.Stream do
@@ -53,14 +66,18 @@ defimpl DBConnection.Query, for: Postgrex.Stream do
     raise "can not describe #{inspect stream}"
   end
 
-  def encode(%Postgrex.Stream{query: query, state: nil}, params, opts) do
+  def encode(%Postgrex.Stream{query: query, state: :bind}, params, opts) do
     DBConnection.Query.encode(query, params, opts)
   end
 
-  def encode(%Postgrex.Stream{state: :suspended}, params, _) do
+  def encode(%Postgrex.Stream{state: state}, params, _)
+      when state in [:out, :suspended, :copy_out] do
     params
   end
 
+  def decode(%Postgrex.Stream{state: :bind}, result, _) do
+    result
+  end
   def decode(%Postgrex.Stream{query: query}, result, opts) do
     DBConnection.Query.decode(query, result, opts)
   end

--- a/lib/postgrex/stream.ex
+++ b/lib/postgrex/stream.ex
@@ -2,6 +2,10 @@ defmodule Postgrex.Stream do
   defstruct [:conn, :options, :params, :portal, :query, :ref, state: :bind, max_rows: 500]
 end
 
+defmodule Postgrex.CopyData do
+  defstruct [:data]
+end
+
 defimpl Enumerable, for: Postgrex.Stream do
   def reduce(stream, acc, fun) do
     Stream.resource(fn() -> start(stream) end, &next/1, &close/1).(acc, fun)
@@ -19,7 +23,7 @@ defimpl Enumerable, for: Postgrex.Stream do
     %Postgrex.Stream{conn: conn, params: params, options: options} = stream
     stream = maybe_generate_portal(stream)
     _ = Postgrex.execute!(conn, stream, params, options)
-    %Postgrex.Stream{stream | state: :out}
+    %Postgrex.Stream{stream | state: :execute}
   end
 
   defp next(%Postgrex.Stream{state: :done} = stream) do
@@ -29,11 +33,11 @@ defimpl Enumerable, for: Postgrex.Stream do
     %Postgrex.Stream{conn: conn, params: params, options: options,
                      state: state} = stream
     case Postgrex.execute!(conn, stream, params, options) do
-      %Postgrex.Result{command: :stream} = result when state == :out ->
+      %Postgrex.Result{command: :stream} = result when state == :execute ->
         {[result], %Postgrex.Stream{stream | state: :suspended}}
       %Postgrex.Result{command: :stream} = result when state == :suspended ->
         {[result], stream}
-      %Postgrex.Result{command: :copy_stream} = result when state == :out ->
+      %Postgrex.Result{command: :copy_stream} = result when state == :execute ->
         {[result], %Postgrex.Stream{stream | state: :copy_out}}
       %Postgrex.Result{command: :copy_stream} = result when state == :copy_out ->
         {[result], stream}
@@ -57,6 +61,27 @@ defimpl Enumerable, for: Postgrex.Stream do
   end
 end
 
+defimpl Collectable, for: Postgrex.Stream do
+  def into(stream) do
+   {:ok, make_into(stream)}
+  end
+
+  defp make_into(stream) do
+    %Postgrex.Stream{conn: conn, params: params, options: options} = stream
+    copy_stream = %Postgrex.Stream{stream | state: :copy_in}
+    fn
+      :ok, {:cont, data} ->
+        data = %Postgrex.CopyData{data: data}
+        _ = Postgrex.execute!(conn, copy_stream, [data | params], options)
+        :ok
+      :ok, :done ->
+        stream
+      :ok, :halt ->
+        :ok
+    end
+  end
+end
+
 defimpl DBConnection.Query, for: Postgrex.Stream do
   def parse(stream, _) do
     raise "can not prepare #{inspect stream}"
@@ -71,8 +96,21 @@ defimpl DBConnection.Query, for: Postgrex.Stream do
   end
 
   def encode(%Postgrex.Stream{state: state}, params, _)
-      when state in [:out, :suspended, :copy_out] do
+      when state in [:execute, :suspended, :copy_out] do
     params
+  end
+
+  def encode(%Postgrex.Stream{query: query, state: :copy_in}, [data | params], opts) do
+    %Postgrex.CopyData{data: data} = data
+    try do
+      IO.iodata_length(data)
+    rescue
+      ArgumentError ->
+        raise "expected to iodata to copy to database, got: " <> inspect(data)
+    else
+      _ ->
+        [data | DBConnection.Query.encode(query, params, opts)]
+    end
   end
 
   def decode(%Postgrex.Stream{state: :bind}, result, _) do

--- a/test/query_test.exs
+++ b/test/query_test.exs
@@ -762,14 +762,14 @@ defmodule QueryTest do
       query("COPY uniques FROM STDIN", [])
   end
 
-  test "COPY TO STDOUT raises", context do
-    Process.flag(:trap_exit, true)
+  test "COPY TO STDOUT", context do
+    assert [] = query("COPY uniques TO STDOUT", [])
+    assert ["1\t2\n"] = query("COPY (VALUES (1, 2)) TO STDOUT", [])
+    assert ["1\t2\n", "3\t4\n"] = query("COPY (VALUES (1, 2), (3, 4)) TO STDOUT", [])
+  end
 
-    capture_log fn() ->
-      assert_raise ArgumentError, ~r"trying to copy but it is not supported",
-        fn() -> query("COPY uniques TO STDOUT", []) end
-      pid = context[:pid]
-      assert_receive {:EXIT, ^pid, {:shutdown, %ArgumentError{}}}
-    end
+  test "COPY TO STDOUT with decoder_mapper", context do
+    opts = [decode_mapper: &String.split/1]
+    assert [["1","2"], ["3","4"]] = query("COPY (VALUES (1, 2), (3, 4)) TO STDOUT", [], opts)
   end
 end

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -348,4 +348,145 @@ defmodule StreamTest do
         |> Enum.to_list()
     end)
   end
+
+  test "COPY empty FROM STDIN", context do
+    query = prepare("", "COPY uniques FROM STDIN")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into([], stream) == stream
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "COPY FROM STDIN", context do
+    query = prepare("", "COPY uniques FROM STDIN")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["2\n", "3\n4\n"], stream) == stream
+      assert Enum.into(["5\n"], stream) == stream
+      assert %Postgrex.Result{rows: [[2], [3], [4], [5]]} =
+        Postgrex.query!(conn, "SELECT * FROM uniques", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "prepare query and stream into different query with same name raises", context do
+    query = prepare("ENOENT", "SELECT 42")
+    :ok = close(query)
+    _ = prepare("ENOENT", "SELECT 41")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert_raise Postgrex.Error, ~r"ERROR \(duplicate_prepared_statement\)",
+        fn -> Enum.into(["1\n"], stream) end
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "prepare, close and stream into COPY FROM", context do
+    query = prepare("copy", "COPY uniques FROM STDIN")
+    :ok = close(query)
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["2\n"], stream) == stream
+      assert %Postgrex.Result{rows: [[2]]} = Postgrex.query!(conn, "SELECT * FROM uniques", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  @tag prepare: :unnamed
+  test "stream named COPY FROM is unnamed when named not allowed", context do
+    assert (%Postgrex.Query{name: ""} = query) = prepare("copy", "COPY uniques FROM STDIN")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["2\n", "3\n4\n"], stream) == stream
+      assert Enum.into(["5\n"], stream) == stream
+      assert %Postgrex.Result{rows: [[2], [3], [4], [5]]} = Postgrex.query!(conn, "SELECT * FROM uniques", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "COPY FROM prepared query on another connection", context do
+    query = prepare("copy", "COPY uniques FROM STDIN")
+
+    {:ok, pid2} = Postgrex.start_link(context[:options])
+    Postgrex.transaction(pid2, fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["2\n"], stream) == stream
+      assert %Postgrex.Result{rows: [[2]]} = Postgrex.query!(conn, "SELECT * FROM uniques", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "raise when executing prepared COPY FROM on connection with different types", context do
+    query = prepare("copy", "COPY uniques FROM STDIN")
+
+    {:ok, pid2} = Postgrex.start_link([decode_binary: :reference] ++ context[:options])
+
+    Postgrex.transaction(pid2, fn(conn) ->
+      assert_raise ArgumentError, ~r"invalid types for the connection",
+        fn() -> Enum.into(["1\n"], stream(query, [])) end
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "connection reuses prepared for COPY FROM after query", context do
+    query = prepare("", "COPY uniques FROM STDIN")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert %Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+      assert Enum.into(["5\n"], stream) == stream
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "connection forces prepare on COPY FROM after prepare of same name", context do
+    query_select = prepare("", "SELECT 42")
+    query_copy = prepare("", "COPY uniques FROM STDIN")
+    transaction(fn(conn) ->
+      stream = stream(query_copy, [])
+      assert %Result{rows: [[42]]} = Postgrex.execute!(conn, query_select, [])
+      assert Enum.into(["5\n"], stream) == stream
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "raise when trying to COPY FROM unprepared query", context do
+    query = %Postgrex.Query{name: "ENOENT", statement: "COPY uniques FROM STDIN"}
+
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert_raise ArgumentError, ~r/has not been prepared/,
+        fn -> Enum.into(["5\n"], stream) end
+    end)
+  end
+
+  test "raise when trying to COPY FROM reserved query", context do
+    query = prepare("", "COPY uniques FROM STDIN")
+
+    transaction(fn(conn) ->
+      stream = stream(%Postgrex.Query{query | name: "POSTGREX_BEGIN"}, [])
+      assert_raise ArgumentError, ~r/uses reserved name/,
+        fn -> Enum.into(["5\n"], stream) end
+    end)
+  end
+
+  test "stream into SELECT ignores data", context do
+    query = prepare("", "SELECT 42")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["42\n", "42\n"], stream) == stream
+      assert %Result{rows: [[41]]} = Postgrex.query!(conn, "SELECT 41", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
+
+  test "stream into COPY TO STDOUT ignores data", context do
+    query = prepare("", "COPY (VALUES (1), (2)) TO STDOUT")
+    transaction(fn(conn) ->
+      stream = stream(query, [])
+      assert Enum.into(["42\n", "42\n"], stream) == stream
+      assert %Result{rows: [[42]]} = Postgrex.query!(conn, "SELECT 42", [])
+      Postgrex.rollback(conn, :done)
+    end)
+  end
 end


### PR DESCRIPTION
"COPY TO STDOUT" works exactly like a normal query except a list of binaries rows is included in the result. When using a stream it is not possible to intersperse other queries on the same connection due to a limitation in the postgresql protocol.

"COPY FROM STDIN" only works when used as a stream in a collectable (and the collectable feature is useless unless copying). The current implementation repeats the query for each data inserted from the enumerable. If the query is not a "COPY FROM STDIN" the data is ignored because that is what postgresql does.